### PR TITLE
feat: OpenMeet private events integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,9 @@ COOKIE_SECRET=
 
 # Set to your tunnel URL to use a confidential client in dev
 # OAUTH_PUBLIC_URL=https://your-tunnel.trycloudflare.com
+
+# OpenMeet integration (optional — set VITE_OPENMEET_URL to enable)
+# When not set, the app uses Contrail only (no private events).
+# VITE_OPENMEET_URL=https://api.openmeet.net
+# VITE_OPENMEET_SERVICE_DID=did:web:api.openmeet.net
+# VITE_OPENMEET_TENANT_ID=lsdfaopkljdfs

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -11,6 +11,7 @@ declare global {
 			session: OAuthSession | null;
 			client: Client | null;
 			did: Did | null;
+			openmeetToken: string | null;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,15 @@
 import type { Handle } from '@sveltejs/kit';
 import { restoreSession } from '$lib/atproto/server/session';
+import { connectToOpenMeet } from '$lib/openmeet/auth';
+import { OPENMEET_ENABLED } from '$lib/openmeet/client';
+import type { OpenMeetTokens } from '$lib/openmeet/types';
+
+// Simple in-memory cache for OpenMeet tokens (per DID)
+const openmeetTokens = new Map<string, { token: string; expiresAt: number }>();
+const TOKEN_TTL_MS = 50 * 60 * 1000; // 50 minutes (tokens last 60min, refresh early)
+
+// Coalesce concurrent refresh attempts for the same DID
+const pendingRefreshes = new Map<string, Promise<OpenMeetTokens | null>>();
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const { session, client, did } = await restoreSession(
@@ -10,6 +20,31 @@ export const handle: Handle = async ({ event, resolve }) => {
 	event.locals.session = session;
 	event.locals.client = client;
 	event.locals.did = did;
+	event.locals.openmeetToken = null;
+
+	// If user is authenticated and OpenMeet is configured, try to get/restore a token
+	if (OPENMEET_ENABLED && did && client) {
+		const cached = openmeetTokens.get(did);
+		if (cached && cached.expiresAt > Date.now()) {
+			event.locals.openmeetToken = cached.token;
+		} else {
+			// Coalesce concurrent refreshes for the same DID
+			let promise = pendingRefreshes.get(did);
+			if (!promise) {
+				promise = connectToOpenMeet(client).finally(() => pendingRefreshes.delete(did));
+				pendingRefreshes.set(did, promise);
+			}
+
+			const tokens = await promise;
+			if (tokens) {
+				event.locals.openmeetToken = tokens.token;
+				openmeetTokens.set(did, {
+					token: tokens.token,
+					expiresAt: Date.now() + TOKEN_TTL_MS
+				});
+			}
+		}
+	}
 
 	return resolve(event);
 };

--- a/src/lib/atproto/settings.ts
+++ b/src/lib/atproto/settings.ts
@@ -15,8 +15,12 @@ export const scopes = [
 	'atproto',
 	scope.repo({ collection: [...collections] }),
 	scope.blob({ accept: ['image/*'] }),
+	// aud=* is required — PDS doesn't support specific-DID rpc scoping:
+	// bare DID gets silently dropped from consent, DID#fragment shows in consent
+	// but getServiceAuth rejects fragments as invalid DIDs. Security is enforced
+	// API-side: verifyAndExchange() validates aud matches SERVICE_DID.
 	...(OPENMEET_SERVICE_DID
-		? [scope.rpc({ lxm: ['net.openmeet.auth'], aud: OPENMEET_SERVICE_DID })]
+		? [scope.rpc({ lxm: ['net.openmeet.auth'], aud: '*' })]
 		: [])
 ];
 

--- a/src/lib/atproto/settings.ts
+++ b/src/lib/atproto/settings.ts
@@ -10,10 +10,14 @@ export const collections = [
 export type AllowedCollection = (typeof collections)[number];
 
 // OAuth scope — add scope.blob(), scope.rpc(), etc. as needed
+const OPENMEET_SERVICE_DID = import.meta.env.VITE_OPENMEET_SERVICE_DID;
 export const scopes = [
 	'atproto',
 	scope.repo({ collection: [...collections] }),
-	scope.blob({ accept: ['image/*'] })
+	scope.blob({ accept: ['image/*'] }),
+	...(OPENMEET_SERVICE_DID
+		? [scope.rpc({ lxm: ['net.openmeet.auth'], aud: OPENMEET_SERVICE_DID })]
+		: [])
 ];
 
 // set to false to disable signup

--- a/src/lib/cal/helper.ts
+++ b/src/lib/cal/helper.ts
@@ -1,3 +1,27 @@
+export function formatMonth(date: Date): string {
+	return date.toLocaleDateString('en-US', { month: 'short' }).toUpperCase();
+}
+
+export function formatDay(date: Date): number {
+	return date.getDate();
+}
+
+export function formatWeekday(date: Date): string {
+	return date.toLocaleDateString('en-US', { weekday: 'long' });
+}
+
+export function formatFullDate(date: Date): string {
+	const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric' };
+	if (date.getFullYear() !== new Date().getFullYear()) {
+		options.year = 'numeric';
+	}
+	return date.toLocaleDateString('en-US', options);
+}
+
+export function formatTime(date: Date): string {
+	return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
 export function validateLink(
 	link: string | undefined,
 	tryAdding: boolean = true

--- a/src/lib/components/EventDetail.svelte
+++ b/src/lib/components/EventDetail.svelte
@@ -9,8 +9,8 @@
 		imageAlt = undefined,
 		avatarSeed,
 		showImage = true,
-		startDate,
-		endDate = null,
+		startsAt,
+		endsAt = null,
 		descriptionHtml = null,
 		location = null,
 		banner,
@@ -26,8 +26,8 @@
 		imageAlt?: string;
 		avatarSeed: string;
 		showImage?: boolean;
-		startDate: Date;
-		endDate?: Date | null;
+		startsAt: Date;
+		endsAt?: Date | null;
 		descriptionHtml?: string | null;
 		location?: { text: string; secondaryText?: string; mapsUrl: string } | null;
 		banner?: Snippet;
@@ -40,10 +40,10 @@
 	} = $props();
 
 	let isSameDay = $derived(
-		endDate &&
-			startDate.getFullYear() === endDate.getFullYear() &&
-			startDate.getMonth() === endDate.getMonth() &&
-			startDate.getDate() === endDate.getDate()
+		endsAt &&
+			startsAt.getFullYear() === endsAt.getFullYear() &&
+			startsAt.getMonth() === endsAt.getMonth() &&
+			startsAt.getDate() === endsAt.getDate()
 	);
 </script>
 
@@ -108,23 +108,23 @@
 						<span
 							class="text-base-500 dark:text-base-400 text-[9px] leading-none font-semibold"
 						>
-							{formatMonth(startDate)}
+							{formatMonth(startsAt)}
 						</span>
 						<span class="text-base-900 dark:text-base-50 text-lg leading-tight font-bold">
-							{formatDay(startDate)}
+							{formatDay(startsAt)}
 						</span>
 					</div>
 					<div>
 						<p class="text-base-900 dark:text-base-50 font-semibold">
-							{formatWeekday(startDate)}, {formatFullDate(startDate)}
-							{#if endDate && !isSameDay}
-								- {formatWeekday(endDate)}, {formatFullDate(endDate)}
+							{formatWeekday(startsAt)}, {formatFullDate(startsAt)}
+							{#if endsAt && !isSameDay}
+								- {formatWeekday(endsAt)}, {formatFullDate(endsAt)}
 							{/if}
 						</p>
 						<p class="text-base-500 dark:text-base-400 text-sm">
-							{formatTime(startDate)}
-							{#if endDate && isSameDay}
-								- {formatTime(endDate)}
+							{formatTime(startsAt)}
+							{#if endsAt && isSameDay}
+								- {formatTime(endsAt)}
 							{/if}
 						</p>
 					</div>

--- a/src/lib/components/EventDetail.svelte
+++ b/src/lib/components/EventDetail.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import Avatar from 'svelte-boring-avatars';
+	import { formatMonth, formatDay, formatWeekday, formatFullDate, formatTime } from '$lib/cal/helper';
+
+	let {
+		name,
+		image = null,
+		imageAlt = undefined,
+		avatarSeed,
+		showImage = true,
+		startDate,
+		endDate = null,
+		descriptionHtml = null,
+		location = null,
+		banner,
+		imageExtra,
+		badges,
+		rsvp,
+		sidebar,
+		aboveDescription,
+		belowDescription
+	}: {
+		name: string;
+		image?: string | null;
+		imageAlt?: string;
+		avatarSeed: string;
+		showImage?: boolean;
+		startDate: Date;
+		endDate?: Date | null;
+		descriptionHtml?: string | null;
+		location?: { text: string; secondaryText?: string; mapsUrl: string } | null;
+		banner?: Snippet;
+		imageExtra?: Snippet;
+		badges?: Snippet;
+		rsvp?: Snippet;
+		sidebar?: Snippet;
+		aboveDescription?: Snippet;
+		belowDescription?: Snippet;
+	} = $props();
+
+	let isSameDay = $derived(
+		endDate &&
+			startDate.getFullYear() === endDate.getFullYear() &&
+			startDate.getMonth() === endDate.getMonth() &&
+			startDate.getDate() === endDate.getDate()
+	);
+</script>
+
+<div class="min-h-screen px-6 py-12 sm:py-12">
+	<div class="mx-auto max-w-3xl">
+		{#if banner}
+			{@render banner()}
+		{/if}
+
+		<div
+			class="grid grid-cols-1 gap-8 md:grid-cols-[14rem_1fr] md:grid-rows-[auto_1fr] md:gap-x-10 md:gap-y-6 lg:grid-cols-[16rem_1fr]"
+		>
+			<!-- Left column: image -->
+			{#if showImage}
+				<div class="order-1 max-w-sm md:order-0 md:col-start-1 md:max-w-none">
+					{#if image}
+						<img
+							src={image}
+							alt={imageAlt || name}
+							class="border-base-200 dark:border-base-800 bg-base-200 dark:bg-base-950/50 aspect-square w-full rounded-2xl border object-cover"
+						/>
+					{:else}
+						<div
+							class="border-base-200 dark:border-base-800 aspect-square w-full overflow-hidden rounded-2xl border [&>svg]:h-full [&>svg]:w-full"
+						>
+							<Avatar
+								size={256}
+								name={avatarSeed}
+								variant="marble"
+								colors={['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90']}
+								square
+							/>
+						</div>
+					{/if}
+					{#if imageExtra}
+						{@render imageExtra()}
+					{/if}
+				</div>
+			{/if}
+
+			<!-- Right column: event details -->
+			<div class="order-2 min-w-0 md:order-0 md:col-start-2 md:row-span-2 md:row-start-1">
+				<div class="mb-2">
+					<h1
+						class="text-base-900 dark:text-base-50 text-3xl leading-tight font-bold sm:text-4xl"
+					>
+						{name}
+					</h1>
+				</div>
+
+				{#if badges}
+					<div class="mb-8 flex items-center gap-2">
+						{@render badges()}
+					</div>
+				{/if}
+
+				<!-- Date row -->
+				<div class="mb-4 flex items-center gap-4">
+					<div
+						class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 flex-col items-center justify-center overflow-hidden rounded-xl border"
+					>
+						<span
+							class="text-base-500 dark:text-base-400 text-[9px] leading-none font-semibold"
+						>
+							{formatMonth(startDate)}
+						</span>
+						<span class="text-base-900 dark:text-base-50 text-lg leading-tight font-bold">
+							{formatDay(startDate)}
+						</span>
+					</div>
+					<div>
+						<p class="text-base-900 dark:text-base-50 font-semibold">
+							{formatWeekday(startDate)}, {formatFullDate(startDate)}
+							{#if endDate && !isSameDay}
+								- {formatWeekday(endDate)}, {formatFullDate(endDate)}
+							{/if}
+						</p>
+						<p class="text-base-500 dark:text-base-400 text-sm">
+							{formatTime(startDate)}
+							{#if endDate && isSameDay}
+								- {formatTime(endDate)}
+							{/if}
+						</p>
+					</div>
+				</div>
+
+				<!-- Location -->
+				{#if location}
+					<a
+						href={location.mapsUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="mb-6 flex items-center gap-4 transition-opacity hover:opacity-80"
+					>
+						<div
+							class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 items-center justify-center rounded-xl border"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="1.5"
+								stroke="currentColor"
+								class="text-base-900 dark:text-base-200 size-5"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+								/>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
+								/>
+							</svg>
+						</div>
+						<div>
+							<p class="text-base-900 dark:text-base-50 font-semibold">{location.text}</p>
+							{#if location.secondaryText}
+								<p class="text-base-500 dark:text-base-400 text-sm">
+									{location.secondaryText}
+								</p>
+							{/if}
+						</div>
+					</a>
+				{/if}
+
+				{#if aboveDescription}
+					{@render aboveDescription()}
+				{/if}
+
+				{#if rsvp}
+					{@render rsvp()}
+				{/if}
+
+				{#if descriptionHtml}
+					<div class="mt-8 mb-8">
+						<p
+							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+						>
+							About
+						</p>
+						<div
+							class="text-base-700 dark:text-base-300 prose dark:prose-invert prose-a:text-accent-600 dark:prose-a:text-accent-400 prose-a:hover:underline prose-a:no-underline max-w-none leading-relaxed wrap-break-word"
+						>
+							{@html descriptionHtml}
+						</div>
+					</div>
+				{/if}
+
+				{#if belowDescription}
+					{@render belowDescription()}
+				{/if}
+			</div>
+
+			<!-- Left column: sidebar -->
+			<div class="order-3 space-y-6 md:order-0 md:col-start-1">
+				{#if sidebar}
+					{@render sidebar()}
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -12,11 +12,13 @@
 		zoom?: number;
 	} = $props();
 
-	let center = $state({ lng, lat });
+	let center: { lng: number; lat: number } = $state({ lng: 0, lat: 0 });
 	let showAttribution = $state(false);
 	let map: maplibregl.Map | undefined = $state();
 
-	const fixedCenter = { lng, lat };
+	$effect(() => { center = { lng, lat }; });
+
+	let fixedCenter = $derived({ lng, lat });
 
 	function handleZoom() {
 		if (map) {

--- a/src/lib/components/OpenMeetEventCard.svelte
+++ b/src/lib/components/OpenMeetEventCard.svelte
@@ -13,6 +13,24 @@
 			minute: '2-digit'
 		});
 	}
+
+	function getLocationString(locations: OpenMeetEvent['locations']): string | undefined {
+		if (!locations?.length) return undefined;
+		const loc = locations[0];
+		return loc.description || [loc.locality, loc.region].filter(Boolean).join(', ') || undefined;
+	}
+
+	function getModeLabel(mode: string | undefined): string | undefined {
+		if (!mode) return undefined;
+		if (mode.includes('virtual')) return 'Virtual';
+		if (mode.includes('hybrid')) return 'Hybrid';
+		if (mode.includes('inperson')) return 'In-Person';
+		return undefined;
+	}
+
+	let thumbnail = $derived(event.media?.find((m) => m.role === 'thumbnail')?.url);
+	let location = $derived(getLocationString(event.locations));
+	let mode = $derived(getModeLabel(event.mode));
 </script>
 
 <a
@@ -20,9 +38,9 @@
 	class="group grid grid-cols-[4rem_1fr] gap-3 transition-colors sm:grid-cols-[5rem_1fr] sm:gap-4"
 >
 	<div class="w-full">
-		{#if event.image}
+		{#if thumbnail}
 			<img
-				src={event.image}
+				src={thumbnail}
 				alt={event.name}
 				class="border-base-200 dark:border-base-800 aspect-square w-full rounded-2xl border object-cover"
 			/>
@@ -43,7 +61,7 @@
 
 	<div class="min-w-0 self-center">
 		<p class="text-base-500 dark:text-base-400 flex items-center gap-1.5 text-xs font-medium">
-			{formatDateTime(event.startDate)}
+			{formatDateTime(event.startsAt)}
 			{#if event.visibility !== 'public'}
 				<span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-2.5">
@@ -58,10 +76,14 @@
 		>
 			{event.name}
 		</h3>
-		{#if event.location || event.group}
+		{#if location || mode || event.group}
 			<p class="text-base-500 dark:text-base-400 mt-1 text-xs">
-				{#if event.location}{event.location}{/if}
-				{#if event.location && event.group}
+				{#if location}{location}{/if}
+				{#if location && (mode || event.group)}
+					<span class="mx-1">&middot;</span>
+				{/if}
+				{#if mode}{mode}{/if}
+				{#if mode && event.group}
 					<span class="mx-1">&middot;</span>
 				{/if}
 				{#if event.group}{event.group.name}{/if}

--- a/src/lib/components/OpenMeetEventCard.svelte
+++ b/src/lib/components/OpenMeetEventCard.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import type { OpenMeetEvent } from '$lib/openmeet/types';
+	import Avatar from 'svelte-boring-avatars';
+
+	let { event }: { event: OpenMeetEvent } = $props();
+
+	function formatDateTime(dateStr: string): string {
+		return new Date(dateStr).toLocaleDateString('en-US', {
+			weekday: 'short',
+			month: 'short',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: '2-digit'
+		});
+	}
+</script>
+
+<a
+	href="/om/{event.slug}"
+	class="group grid grid-cols-[4rem_1fr] gap-3 transition-colors sm:grid-cols-[5rem_1fr] sm:gap-4"
+>
+	<div class="w-full">
+		{#if event.image}
+			<img
+				src={event.image}
+				alt={event.name}
+				class="border-base-200 dark:border-base-800 aspect-square w-full rounded-2xl border object-cover"
+			/>
+		{:else}
+			<div
+				class="border-base-200 dark:border-base-800 aspect-square w-full overflow-hidden rounded-2xl border [&>svg]:h-full [&>svg]:w-full"
+			>
+				<Avatar
+					size={80}
+					name={event.slug}
+					variant="marble"
+					colors={['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90']}
+					square
+				/>
+			</div>
+		{/if}
+	</div>
+
+	<div class="min-w-0 self-center">
+		<p class="text-base-500 dark:text-base-400 flex items-center gap-1.5 text-xs font-medium">
+			{formatDateTime(event.startDate)}
+			{#if event.visibility !== 'public'}
+				<span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-2.5">
+						<path fill-rule="evenodd" d="M8 1a3.5 3.5 0 0 0-3.5 3.5V7A1.5 1.5 0 0 0 3 8.5v5A1.5 1.5 0 0 0 4.5 15h7a1.5 1.5 0 0 0 1.5-1.5v-5A1.5 1.5 0 0 0 11.5 7V4.5A3.5 3.5 0 0 0 8 1Zm2 6V4.5a2 2 0 1 0-4 0V7h4Z" clip-rule="evenodd" />
+					</svg>
+					Private
+				</span>
+			{/if}
+		</p>
+		<h3
+			class="text-base-900 dark:text-base-50 group-hover:text-base-700 dark:group-hover:text-base-200 mt-0.5 line-clamp-2 text-sm leading-snug font-semibold transition-colors sm:text-base"
+		>
+			{event.name}
+		</h3>
+		{#if event.location || event.group}
+			<p class="text-base-500 dark:text-base-400 mt-1 text-xs">
+				{#if event.location}{event.location}{/if}
+				{#if event.location && event.group}
+					<span class="mx-1">&middot;</span>
+				{/if}
+				{#if event.group}{event.group.name}{/if}
+			</p>
+		{/if}
+	</div>
+</a>

--- a/src/lib/openmeet/auth.ts
+++ b/src/lib/openmeet/auth.ts
@@ -1,0 +1,49 @@
+import type { Client } from '@atcute/client';
+import type { OpenMeetTokens } from './types';
+import { exchangeServiceAuth } from './client';
+
+const OPENMEET_SERVICE_DID = import.meta.env.VITE_OPENMEET_SERVICE_DID || 'did:web:api.openmeet.net';
+
+/**
+ * Authenticate to OpenMeet using the user's ATProto session.
+ *
+ * Flow: getServiceAuth (PDS signs a JWT) → exchange at OpenMeet → get session tokens.
+ * The user's signing key never leaves their PDS.
+ *
+ * We exchange for OpenMeet tokens rather than passing PDS service auth tokens
+ * directly to each API call because PDS tokens are short-lived (~60s). The
+ * exchange gives us a ~60min token we can cache, avoiding a PDS round-trip on
+ * every page load. The alternative — accepting PDS tokens directly on the DID
+ * API — would be simpler (no exchange, no session) but adds latency per request.
+ */
+export async function connectToOpenMeet(client: Client): Promise<OpenMeetTokens | null> {
+	try {
+		// Ask the user's PDS to sign a service auth token for OpenMeet
+		const response = await client.get('com.atproto.server.getServiceAuth', {
+			params: {
+				aud: OPENMEET_SERVICE_DID,
+				lxm: 'net.openmeet.auth'
+			}
+		});
+
+		// response.data is typed as { token: string } | XRPCErrorPayload
+		const token = (response.data as Record<string, unknown>).token as string | undefined;
+		if (!token) {
+			console.error('OpenMeet connect: PDS response:', JSON.stringify(response));
+			return null;
+		}
+
+		// Exchange PDS-signed token for OpenMeet session tokens
+		const tokens = await exchangeServiceAuth(token);
+		if (!tokens) {
+			console.error('OpenMeet connect: token exchange failed');
+			return null;
+		}
+
+		return tokens;
+	} catch (err: unknown) {
+		const detail = err instanceof Error ? err.message : JSON.stringify(err);
+		console.error('OpenMeet connect failed:', detail);
+		return null;
+	}
+}

--- a/src/lib/openmeet/client.ts
+++ b/src/lib/openmeet/client.ts
@@ -58,22 +58,35 @@ export async function getEvent(
 	return res.json();
 }
 
-export async function attendEvent(accessToken: string, slug: string): Promise<{ status: string } | null> {
+export async function attendEvent(
+	accessToken: string,
+	slug: string
+): Promise<{ ok: true; status: string } | { ok: false; error: string }> {
 	const res = await fetch(`${OPENMEET_URL}/api/events/${slug}/attend`, {
 		method: 'POST',
 		headers: headers(accessToken)
 	});
-	if (!res.ok) return null;
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		return { ok: false, error: (body as { message?: string }).message || `RSVP failed (${res.status})` };
+	}
 	const data = (await res.json()) as { status?: string };
-	return { status: data.status || 'confirmed' };
+	return { ok: true, status: data.status || 'confirmed' };
 }
 
-export async function cancelAttendEvent(accessToken: string, slug: string): Promise<boolean> {
+export async function cancelAttendEvent(
+	accessToken: string,
+	slug: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
 	const res = await fetch(`${OPENMEET_URL}/api/events/${slug}/cancel-attending`, {
 		method: 'POST',
 		headers: headers(accessToken)
 	});
-	return res.ok;
+	if (!res.ok) {
+		const body = await res.json().catch(() => ({}));
+		return { ok: false, error: (body as { message?: string }).message || `Cancel failed (${res.status})` };
+	}
+	return { ok: true };
 }
 
 /**

--- a/src/lib/openmeet/client.ts
+++ b/src/lib/openmeet/client.ts
@@ -1,0 +1,95 @@
+import type { OpenMeetEvent, OpenMeetGroup, OpenMeetTokens } from './types';
+
+const OPENMEET_URL = import.meta.env.VITE_OPENMEET_URL;
+const TENANT_ID = import.meta.env.VITE_OPENMEET_TENANT_ID || 'lsdfaopkljdfs';
+
+/** True when OpenMeet integration is configured */
+export const OPENMEET_ENABLED = !!OPENMEET_URL;
+
+function headers(accessToken: string): Record<string, string> {
+	return {
+		Authorization: `Bearer ${accessToken}`,
+		'x-tenant-id': TENANT_ID
+	};
+}
+
+export async function listMyGroups(accessToken: string): Promise<OpenMeetGroup[]> {
+	const res = await fetch(`${OPENMEET_URL}/api/v1/did/groups`, {
+		headers: headers(accessToken)
+	});
+	if (!res.ok) return [];
+	const data = (await res.json()) as { groups?: OpenMeetGroup[] };
+	return data.groups ?? [];
+}
+
+export async function listMyEvents(
+	accessToken: string,
+	params?: {
+		fromDate?: string;
+		toDate?: string;
+		groupSlug?: string;
+		includePublic?: boolean;
+		limit?: number;
+	}
+): Promise<OpenMeetEvent[]> {
+	const url = new URL(`${OPENMEET_URL}/api/v1/did/events`);
+	if (params?.fromDate) url.searchParams.set('fromDate', params.fromDate);
+	if (params?.toDate) url.searchParams.set('toDate', params.toDate);
+	if (params?.groupSlug) url.searchParams.set('groupSlug', params.groupSlug);
+	if (params?.includePublic) url.searchParams.set('includePublic', 'true');
+	if (params?.limit) url.searchParams.set('limit', String(params.limit));
+
+	const res = await fetch(url.toString(), {
+		headers: headers(accessToken)
+	});
+	if (!res.ok) return [];
+	const data = (await res.json()) as { events?: OpenMeetEvent[] };
+	return data.events ?? [];
+}
+
+export async function getEvent(
+	accessToken: string,
+	slug: string
+): Promise<OpenMeetEvent | null> {
+	const res = await fetch(`${OPENMEET_URL}/api/v1/did/events/${slug}`, {
+		headers: headers(accessToken)
+	});
+	if (!res.ok) return null;
+	return res.json();
+}
+
+export async function attendEvent(accessToken: string, slug: string): Promise<{ status: string } | null> {
+	const res = await fetch(`${OPENMEET_URL}/api/events/${slug}/attend`, {
+		method: 'POST',
+		headers: headers(accessToken)
+	});
+	if (!res.ok) return null;
+	const data = (await res.json()) as { status?: string };
+	return { status: data.status || 'confirmed' };
+}
+
+export async function cancelAttendEvent(accessToken: string, slug: string): Promise<boolean> {
+	const res = await fetch(`${OPENMEET_URL}/api/events/${slug}/cancel-attending`, {
+		method: 'POST',
+		headers: headers(accessToken)
+	});
+	return res.ok;
+}
+
+/**
+ * Exchange a PDS service auth token for OpenMeet access/refresh tokens.
+ * The serviceAuthToken is obtained by calling com.atproto.server.getServiceAuth
+ * on the user's PDS with aud=did:web:api.openmeet.net.
+ */
+export async function exchangeServiceAuth(serviceAuthToken: string): Promise<OpenMeetTokens | null> {
+	const res = await fetch(`${OPENMEET_URL}/api/v1/auth/atproto/service-auth`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'x-tenant-id': TENANT_ID
+		},
+		body: JSON.stringify({ token: serviceAuthToken })
+	});
+	if (!res.ok) return null;
+	return res.json();
+}

--- a/src/lib/openmeet/types.ts
+++ b/src/lib/openmeet/types.ts
@@ -50,25 +50,46 @@ export interface OpenMeetEvent {
 	slug: string;
 	name: string;
 	description: string;
-	startDate: string;
-	endDate: string | null;
-	location: string | null;
-	locationOnline: string | null;
-	type: string;
+	// Normalized list fields (lexicon names)
+	startsAt: string;
+	endsAt: string | null;
+	locations: Array<{ $type: string; description?: string; locality?: string; region?: string }>;
+	uris: Array<{ uri: string; name?: string }>;
+	mode: string;
+	uri: string | null;
+	did: string | null;
+	media: Array<{ role: string; alt?: string; url?: string; content?: unknown }>;
+	// Common fields
 	visibility: string;
 	status: string;
-	timeZone: string | null;
-	maxAttendees: number;
-	atprotoUri: string | null;
 	group: OpenMeetEventGroup | null;
-	user: OpenMeetUser | null;
-	attendees: OpenMeetAttendee[];
 	attendeesCount: number;
 	userRsvpStatus: string | null;
-	categories: OpenMeetCategory[];
-	image: string | null;
-	lat: number | null;
-	lon: number | null;
+	// Detail-only fields (present in detail response, not list)
+	timeZone?: string | null;
+	maxAttendees?: number;
+	user?: OpenMeetDetailUser | null;
+	attendees?: OpenMeetDetailAttendee[];
+	categories?: OpenMeetCategory[];
+	lat?: number | null;
+	lon?: number | null;
+}
+
+// Detail endpoint returns a different user/attendee shape than the old types
+export interface OpenMeetDetailUser {
+	did: string | null;
+	handle: string | null;
+	displayName: string;
+	avatar: string | null;
+}
+
+export interface OpenMeetDetailAttendee {
+	did: string | null;
+	handle: string | null;
+	name: string;
+	avatar: string | null;
+	url: string;
+	role: string | null;
 }
 
 export interface OpenMeetTokens {

--- a/src/lib/openmeet/types.ts
+++ b/src/lib/openmeet/types.ts
@@ -1,0 +1,38 @@
+export interface OpenMeetGroup {
+	slug: string;
+	name: string;
+	description: string;
+	visibility: string;
+	role: string;
+	memberCount: number;
+	upcomingEventCount: number;
+	image: string | null;
+}
+
+export interface OpenMeetEventGroup {
+	slug: string;
+	name: string;
+	role: string;
+}
+
+export interface OpenMeetEvent {
+	slug: string;
+	name: string;
+	description: string;
+	startDate: string;
+	endDate: string | null;
+	location: string | null;
+	locationOnline: string | null;
+	type: string;
+	visibility: string;
+	status: string;
+	atprotoUri: string | null;
+	group: OpenMeetEventGroup | null;
+	attendeesCount: number;
+	userRsvpStatus: string | null;
+	image: string | null;
+}
+
+export interface OpenMeetTokens {
+	token: string;
+}

--- a/src/lib/openmeet/types.ts
+++ b/src/lib/openmeet/types.ts
@@ -15,6 +15,37 @@ export interface OpenMeetEventGroup {
 	role: string;
 }
 
+export interface OpenMeetPhoto {
+	path: string;
+}
+
+export interface OpenMeetUser {
+	slug: string;
+	name: string;
+	provider: string;
+	socialId: string | null;
+	isShadowAccount: boolean;
+	photo: OpenMeetPhoto | null;
+}
+
+export interface OpenMeetEventRole {
+	id: number;
+	name: string;
+}
+
+export interface OpenMeetAttendee {
+	id: number;
+	status: string;
+	role: OpenMeetEventRole | null;
+	user: OpenMeetUser;
+}
+
+export interface OpenMeetCategory {
+	id: number;
+	name: string;
+	slug: string;
+}
+
 export interface OpenMeetEvent {
 	slug: string;
 	name: string;
@@ -26,11 +57,18 @@ export interface OpenMeetEvent {
 	type: string;
 	visibility: string;
 	status: string;
+	timeZone: string | null;
+	maxAttendees: number;
 	atprotoUri: string | null;
 	group: OpenMeetEventGroup | null;
+	user: OpenMeetUser | null;
+	attendees: OpenMeetAttendee[];
 	attendeesCount: number;
 	userRsvpStatus: string | null;
+	categories: OpenMeetCategory[];
 	image: string | null;
+	lat: number | null;
+	lon: number | null;
 }
 
 export interface OpenMeetTokens {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -55,7 +55,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	// Filter OpenMeet events: only include those NOT already in Contrail
 	// (private events won't have atprotoUri, so they always pass through)
 	const uniquePrivateEvents = privateEvents.filter(
-		(e: OpenMeetEvent) => !e.atprotoUri || !contrailUris.has(e.atprotoUri)
+		(e: OpenMeetEvent) => !e.uri || !contrailUris.has(e.uri)
 	);
 
 	// Merge into a single sorted array
@@ -68,7 +68,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		})),
 		...uniquePrivateEvents.map((e): OpenMeetDisplayEvent => ({
 			source: 'openmeet',
-			sortDate: e.startDate,
+			sortDate: e.startsAt,
 			event: e
 		}))
 	].sort((a, b) => new Date(a.sortDate).getTime() - new Date(b.sortDate).getTime());

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,28 @@
-import { flattenEventRecords, listEventRecordsFromContrail } from '$lib/contrail';
+import { flattenEventRecords, listEventRecordsFromContrail, type FlatEventRecord } from '$lib/contrail';
+import { listMyEvents } from '$lib/openmeet/client';
+import type { OpenMeetEvent } from '$lib/openmeet/types';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export type ContrailDisplayEvent = {
+	source: 'contrail';
+	sortDate: string;
+	event: FlatEventRecord;
+	actor?: string;
+};
+
+export type OpenMeetDisplayEvent = {
+	source: 'openmeet';
+	sortDate: string;
+	event: OpenMeetEvent;
+};
+
+export type DisplayEvent = ContrailDisplayEvent | OpenMeetDisplayEvent;
+
+export const load: PageServerLoad = async ({ locals }) => {
 	const now = new Date().toISOString();
 
-	const response = await listEventRecordsFromContrail({
+	// Fetch public events from Contrail (always)
+	const contrailPromise = listEventRecordsFromContrail({
 		startsAtMin: now,
 		rsvpsGoingCountMin: 2,
 		hydrateRsvps: 5,
@@ -13,15 +31,50 @@ export const load: PageServerLoad = async () => {
 		limit: 20
 	});
 
-	if (!response) return { events: [], handles: {} };
+	// Fetch private events from OpenMeet (if authenticated)
+	const openmeetPromise = locals.openmeetToken
+		? listMyEvents(locals.openmeetToken, { fromDate: now, limit: 20 })
+		: Promise.resolve([]);
 
+	const [contrailResponse, privateEvents] = await Promise.all([contrailPromise, openmeetPromise]);
+
+	// Build handles map from Contrail profiles
 	const handles: Record<string, string> = {};
-	for (const p of response.profiles ?? []) {
-		if (p.handle) handles[p.did] = p.handle;
+	if (contrailResponse) {
+		for (const p of contrailResponse.profiles ?? []) {
+			if (p.handle) handles[p.did] = p.handle;
+		}
 	}
 
+	// Flatten Contrail events
+	const publicEvents = contrailResponse ? flattenEventRecords(contrailResponse.records) : [];
+
+	// Build a set of atprotoUris from Contrail for dedup
+	const contrailUris = new Set(publicEvents.map((e) => e.uri).filter(Boolean));
+
+	// Filter OpenMeet events: only include those NOT already in Contrail
+	// (private events won't have atprotoUri, so they always pass through)
+	const uniquePrivateEvents = privateEvents.filter(
+		(e: OpenMeetEvent) => !e.atprotoUri || !contrailUris.has(e.atprotoUri)
+	);
+
+	// Merge into a single sorted array
+	const allEvents: DisplayEvent[] = [
+		...publicEvents.map((e): ContrailDisplayEvent => ({
+			source: 'contrail',
+			sortDate: e.startsAt,
+			event: e,
+			actor: handles[e.did]
+		})),
+		...uniquePrivateEvents.map((e): OpenMeetDisplayEvent => ({
+			source: 'openmeet',
+			sortDate: e.startDate,
+			event: e
+		}))
+	].sort((a, b) => new Date(a.sortDate).getTime() - new Date(b.sortDate).getTime());
+
 	return {
-		events: flattenEventRecords(response.records),
+		events: allEvents,
 		handles
 	};
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
 	import EventCard from '$lib/components/EventCard.svelte';
+	import OpenMeetEventCard from '$lib/components/OpenMeetEventCard.svelte';
 	import { Button } from '@foxui/core';
 	import { user } from '$lib/atproto/auth.svelte';
 	import { atProtoLoginModalState } from '@foxui/social';
+	import type { ContrailDisplayEvent, OpenMeetDisplayEvent } from './+page.server';
 
 	let { data } = $props();
+
+	function eventKey(item: ContrailDisplayEvent | OpenMeetDisplayEvent): string {
+		return item.source === 'contrail' ? item.event.uri : `om-${item.event.slug}`;
+	}
 </script>
 
 <div class="mx-auto max-w-3xl px-6 py-8 sm:py-12">
@@ -37,8 +43,12 @@
 		<p class="text-base-500 text-center text-lg">No upcoming events found.</p>
 	{:else}
 		<div class="grid gap-6 sm:grid-cols-2">
-			{#each data.events as event (event.uri)}
-				<EventCard {event} actor={data.handles[event.did]} />
+			{#each data.events as item (eventKey(item))}
+				{#if item.source === 'contrail'}
+					<EventCard event={item.event} actor={item.actor} />
+				{:else}
+					<OpenMeetEventCard event={item.event} />
+				{/if}
 			{/each}
 		</div>
 	{/if}

--- a/src/routes/om/[slug]/+page.server.ts
+++ b/src/routes/om/[slug]/+page.server.ts
@@ -26,8 +26,8 @@ export const actions: Actions = {
 			return fail(401, { error: 'Not connected to OpenMeet' });
 		}
 		const result = await attendEvent(locals.openmeetToken, params.slug);
-		if (!result) {
-			return fail(500, { error: 'Failed to RSVP' });
+		if (!result.ok) {
+			return fail(500, { error: result.error });
 		}
 		return { success: true, status: result.status };
 	},
@@ -35,9 +35,9 @@ export const actions: Actions = {
 		if (!locals.openmeetToken) {
 			return fail(401, { error: 'Not connected to OpenMeet' });
 		}
-		const ok = await cancelAttendEvent(locals.openmeetToken, params.slug);
-		if (!ok) {
-			return fail(500, { error: 'Failed to cancel RSVP' });
+		const result = await cancelAttendEvent(locals.openmeetToken, params.slug);
+		if (!result.ok) {
+			return fail(500, { error: result.error });
 		}
 		return { success: true };
 	}

--- a/src/routes/om/[slug]/+page.server.ts
+++ b/src/routes/om/[slug]/+page.server.ts
@@ -1,0 +1,45 @@
+import { error, fail } from '@sveltejs/kit';
+import { getEvent, attendEvent, cancelAttendEvent } from '$lib/openmeet/client';
+import type { PageServerLoad, Actions } from './$types';
+
+export const load: PageServerLoad = async ({ params, locals }) => {
+	if (!locals.openmeetToken) {
+		throw error(401, 'Not connected to OpenMeet');
+	}
+
+	try {
+		const event = await getEvent(locals.openmeetToken, params.slug);
+
+		if (!event) {
+			throw error(404, 'Event not found');
+		}
+
+		return { event };
+	} catch (e) {
+		if (e && typeof e === 'object' && 'status' in e) throw e;
+		throw error(404, 'Event not found');
+	}
+};
+
+export const actions: Actions = {
+	attend: async ({ params, locals }) => {
+		if (!locals.openmeetToken) {
+			return fail(401, { error: 'Not connected to OpenMeet' });
+		}
+		const result = await attendEvent(locals.openmeetToken, params.slug);
+		if (!result) {
+			return fail(500, { error: 'Failed to RSVP' });
+		}
+		return { success: true, status: result.status };
+	},
+	cancel: async ({ params, locals }) => {
+		if (!locals.openmeetToken) {
+			return fail(401, { error: 'Not connected to OpenMeet' });
+		}
+		const ok = await cancelAttendEvent(locals.openmeetToken, params.slug);
+		if (!ok) {
+			return fail(500, { error: 'Failed to cancel RSVP' });
+		}
+		return { success: true };
+	}
+};

--- a/src/routes/om/[slug]/+page.server.ts
+++ b/src/routes/om/[slug]/+page.server.ts
@@ -1,23 +1,22 @@
-import { error, fail } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
 import { getEvent, attendEvent, cancelAttendEvent } from '$lib/openmeet/client';
 import type { PageServerLoad, Actions } from './$types';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
 	if (!locals.openmeetToken) {
-		throw error(401, 'Not connected to OpenMeet');
+		return { state: 'unauthenticated' as const, event: null };
 	}
 
 	try {
 		const event = await getEvent(locals.openmeetToken, params.slug);
 
 		if (!event) {
-			throw error(404, 'Event not found');
+			return { state: 'not_found' as const, event: null };
 		}
 
-		return { event };
-	} catch (e) {
-		if (e && typeof e === 'object' && 'status' in e) throw e;
-		throw error(404, 'Event not found');
+		return { state: 'ok' as const, event };
+	} catch {
+		return { state: 'not_found' as const, event: null };
 	}
 };
 

--- a/src/routes/om/[slug]/+page.svelte
+++ b/src/routes/om/[slug]/+page.svelte
@@ -3,6 +3,7 @@
 	import { marked } from 'marked';
 	import { sanitize } from '$lib/cal/sanitize';
 	import EventDetail from '$lib/components/EventDetail.svelte';
+	import Map from '$lib/components/Map.svelte';
 	import OpenMeetRsvp from './OpenMeetRsvp.svelte';
 
 	let { data } = $props();
@@ -41,6 +42,10 @@
 				mapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`
 			}
 		: null}
+	{@const geoLocation = event.lat != null && event.lon != null
+		? { lat: event.lat, lng: event.lon }
+		: null}
+	{@const hostUrl = event.user?.did ? `/p/${event.user.handle || event.user.did}` : null}
 
 	<EventDetail
 		name={event.name}
@@ -71,6 +76,31 @@
 			<OpenMeetRsvp userRsvpStatus={event.userRsvpStatus} />
 		{/snippet}
 
+		{#snippet belowDescription()}
+			{#if geoLocation && location}
+				<div class="mt-8 mb-8">
+					<p
+						class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+					>
+						Location
+					</p>
+					<a
+						href={location.mapsUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="block transition-opacity hover:opacity-80"
+					>
+						<div class="h-64 w-full overflow-hidden rounded-xl">
+							<Map lat={geoLocation.lat} lng={geoLocation.lng} />
+						</div>
+						<p class="text-base-500 dark:text-base-400 mt-2 text-sm">
+							{event.location}
+						</p>
+					</a>
+				</div>
+			{/if}
+		{/snippet}
+
 		{#snippet sidebar()}
 			<!-- Hosted By -->
 			{#if event.user}
@@ -80,16 +110,34 @@
 					>
 						Hosted By
 					</p>
-					<div
-						class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
-					>
-						<FoxAvatar
-							src={event.user.photo?.path}
-							alt={event.user.name}
-							class="size-8 shrink-0"
-						/>
-						<span class="truncate text-sm">{event.user.name}</span>
-					</div>
+					{#if hostUrl}
+						<a
+							href={hostUrl}
+							class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium transition-opacity hover:opacity-80"
+						>
+							<FoxAvatar
+								src={event.user.avatar}
+								alt={event.user.displayName || event.user.handle || event.user.did}
+								class="size-8 shrink-0"
+							/>
+							<span class="truncate text-sm">
+								{event.user.displayName || event.user.handle || event.user.did}
+							</span>
+						</a>
+					{:else}
+						<div
+							class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
+						>
+							<FoxAvatar
+								src={event.user.avatar}
+								alt={event.user.displayName || 'Organizer'}
+								class="size-8 shrink-0"
+							/>
+							<span class="truncate text-sm">
+								{event.user.displayName || 'Organizer'}
+							</span>
+						</div>
+					{/if}
 				</div>
 			{/if}
 
@@ -117,24 +165,45 @@
 						Attendees
 					</p>
 					<div class="space-y-2">
-						{#each event.attendees as attendee (attendee.id)}
-							<div
-								class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
-							>
-								<FoxAvatar
-									src={attendee.user.photo?.path}
-									alt={attendee.user.name}
-									class="size-8 shrink-0"
-								/>
-								<div class="min-w-0">
-									<span class="truncate text-sm">{attendee.user.name}</span>
-									{#if attendee.role && attendee.role.name !== 'attendee'}
-										<span class="text-base-500 dark:text-base-400 ml-1 text-xs">
-											({attendee.role.name})
-										</span>
-									{/if}
+						{#each event.attendees as attendee (attendee.did || attendee.name)}
+							{#if attendee.url}
+								<a
+									href={attendee.url}
+									class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium transition-opacity hover:opacity-80"
+								>
+									<FoxAvatar
+										src={attendee.avatar}
+										alt={attendee.name || attendee.handle || attendee.did}
+										class="size-8 shrink-0"
+									/>
+									<div class="min-w-0">
+										<span class="truncate text-sm">{attendee.name || attendee.handle || attendee.did}</span>
+										{#if attendee.role && attendee.role !== 'participant'}
+											<span class="text-base-500 dark:text-base-400 ml-1 text-xs">
+												({attendee.role})
+											</span>
+										{/if}
+									</div>
+								</a>
+							{:else}
+								<div
+									class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
+								>
+									<FoxAvatar
+										src={attendee.avatar}
+										alt={attendee.name || 'Attendee'}
+										class="size-8 shrink-0"
+									/>
+									<div class="min-w-0">
+										<span class="truncate text-sm">{attendee.name || 'Attendee'}</span>
+										{#if attendee.role && attendee.role !== 'participant'}
+											<span class="text-base-500 dark:text-base-400 ml-1 text-xs">
+												({attendee.role})
+											</span>
+										{/if}
+									</div>
 								</div>
-							</div>
+							{/if}
 						{/each}
 						{#if event.attendeesCount > event.attendees.length}
 							<p class="text-base-500 dark:text-base-400 text-xs">

--- a/src/routes/om/[slug]/+page.svelte
+++ b/src/routes/om/[slug]/+page.svelte
@@ -8,17 +8,25 @@
 
 	let { data } = $props();
 
-	function getModeLabel(type: string): string {
-		if (type === 'online') return 'Virtual';
-		if (type === 'hybrid') return 'Hybrid';
-		return 'In-Person';
+	function getModeLabel(mode: string | undefined): string {
+		if (!mode) return 'Event';
+		if (mode.includes('virtual')) return 'Virtual';
+		if (mode.includes('hybrid')) return 'Hybrid';
+		if (mode.includes('inperson')) return 'In-Person';
+		return 'Event';
 	}
 
-	function getModeColor(type: string): 'cyan' | 'purple' | 'amber' | 'secondary' {
-		if (type === 'online') return 'cyan';
-		if (type === 'hybrid') return 'purple';
-		if (type === 'in-person' || type === 'in_person') return 'amber';
+	function getModeColor(mode: string | undefined): 'cyan' | 'purple' | 'amber' | 'secondary' {
+		if (!mode) return 'secondary';
+		if (mode.includes('virtual')) return 'cyan';
+		if (mode.includes('hybrid')) return 'purple';
+		if (mode.includes('inperson')) return 'amber';
 		return 'secondary';
+	}
+
+	function getLocationString(locations: Array<{ $type: string; description?: string }> | undefined): string | null {
+		if (!locations?.length) return null;
+		return locations[0].description || null;
 	}
 </script>
 
@@ -36,10 +44,11 @@
 	{@const descriptionHtml = event.description
 		? sanitize(marked.parse(event.description) as string)
 		: null}
-	{@const location = event.location
+	{@const locationStr = getLocationString(event.locations)}
+	{@const location = locationStr
 		? {
-				text: event.location,
-				mapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`
+				text: locationStr,
+				mapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationStr)}`
 			}
 		: null}
 	{@const geoLocation = event.lat != null && event.lon != null
@@ -49,15 +58,15 @@
 
 	<EventDetail
 		name={event.name}
-		image={event.image}
+		image={event.media?.find(m => m.role === 'thumbnail')?.url}
 		avatarSeed={event.slug}
-		startDate={new Date(event.startDate)}
-		endDate={event.endDate ? new Date(event.endDate) : null}
+		startsAt={new Date(event.startsAt)}
+		endsAt={event.endsAt ? new Date(event.endsAt) : null}
 		{descriptionHtml}
 		{location}
 	>
 		{#snippet badges()}
-			<Badge size="md" variant={getModeColor(event.type)}>{getModeLabel(event.type)}</Badge>
+			<Badge size="md" variant={getModeColor(event.mode)}>{getModeLabel(event.mode)}</Badge>
 			<Badge size="md" variant="secondary">{event.visibility}</Badge>
 			{#if event.group}
 				<Badge size="md" variant="secondary">{event.group.name}</Badge>
@@ -94,7 +103,7 @@
 							<Map lat={geoLocation.lat} lng={geoLocation.lng} />
 						</div>
 						<p class="text-base-500 dark:text-base-400 mt-2 text-sm">
-							{event.location}
+							{locationStr}
 						</p>
 					</a>
 				</div>

--- a/src/routes/om/[slug]/+page.svelte
+++ b/src/routes/om/[slug]/+page.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-	import { Badge } from '@foxui/core';
-	import Avatar from 'svelte-boring-avatars';
+	import { Avatar as FoxAvatar, Badge } from '@foxui/core';
 	import { marked } from 'marked';
 	import { sanitize } from '$lib/cal/sanitize';
-	import { formatMonth, formatDay, formatWeekday, formatFullDate, formatTime } from '$lib/cal/helper';
+	import EventDetail from '$lib/components/EventDetail.svelte';
 	import OpenMeetRsvp from './OpenMeetRsvp.svelte';
 
 	let { data } = $props();
-	let event = $derived(data.event);
-
-	let startDate = $derived(new Date(event.startDate));
-	let endDate = $derived(event.endDate ? new Date(event.endDate) : null);
 
 	function getModeLabel(type: string): string {
 		if (type === 'online') return 'Virtual';
@@ -24,182 +19,141 @@
 		if (type === 'in-person' || type === 'in_person') return 'amber';
 		return 'secondary';
 	}
-
-	let isSameDay = $derived(
-		endDate &&
-			startDate.getFullYear() === endDate.getFullYear() &&
-			startDate.getMonth() === endDate.getMonth() &&
-			startDate.getDate() === endDate.getDate()
-	);
-
-	let descriptionHtml = $derived(
-		event.description ? sanitize(marked.parse(event.description) as string) : null
-	);
 </script>
 
 <svelte:head>
-	<title>{event.name}</title>
-	<meta name="description" content={event.description || `Event: ${event.name}`} />
+	{#if data.event}
+		<title>{data.event.name}</title>
+		<meta name="description" content={data.event.description || `Event: ${data.event.name}`} />
+	{:else}
+		<title>Event</title>
+	{/if}
 </svelte:head>
 
-<div class="min-h-screen px-6 py-12 sm:py-12">
-	<div class="mx-auto max-w-3xl">
-		<div
-			class="grid grid-cols-1 gap-8 md:grid-cols-[14rem_1fr] md:grid-rows-[auto_1fr] md:gap-x-10 md:gap-y-6 lg:grid-cols-[16rem_1fr]"
-		>
-			<!-- Left column: image -->
-			<div class="order-1 max-w-sm md:order-0 md:col-start-1 md:max-w-none">
-				{#if event.image}
-					<img
-						src={event.image}
-						alt={event.name}
-						class="border-base-200 dark:border-base-800 aspect-square w-full rounded-2xl border object-cover"
-					/>
-				{:else}
-					<div
-						class="border-base-200 dark:border-base-800 aspect-square w-full overflow-hidden rounded-2xl border [&>svg]:h-full [&>svg]:w-full"
-					>
-						<Avatar
-							size={256}
-							name={event.slug}
-							variant="marble"
-							colors={['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90']}
-							square
-						/>
-					</div>
-				{/if}
-			</div>
+{#if data.state === 'ok' && data.event}
+	{@const event = data.event}
+	{@const descriptionHtml = event.description
+		? sanitize(marked.parse(event.description) as string)
+		: null}
+	{@const location = event.location
+		? {
+				text: event.location,
+				mapsUrl: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`
+			}
+		: null}
 
-			<!-- Right column: event details -->
-			<div class="order-2 min-w-0 md:order-0 md:col-start-2 md:row-span-2 md:row-start-1">
-				<div class="mb-2">
-					<h1
-						class="text-base-900 dark:text-base-50 text-4xl leading-tight font-bold sm:text-5xl"
-					>
-						{event.name}
-					</h1>
-				</div>
+	<EventDetail
+		name={event.name}
+		image={event.image}
+		avatarSeed={event.slug}
+		startDate={new Date(event.startDate)}
+		endDate={event.endDate ? new Date(event.endDate) : null}
+		{descriptionHtml}
+		{location}
+	>
+		{#snippet badges()}
+			<Badge size="md" variant={getModeColor(event.type)}>{getModeLabel(event.type)}</Badge>
+			<Badge size="md" variant="secondary">{event.visibility}</Badge>
+			{#if event.group}
+				<Badge size="md" variant="secondary">{event.group.name}</Badge>
+			{/if}
+		{/snippet}
 
-				<!-- Badges -->
-				<div class="mb-8 flex gap-2">
-					<Badge size="md" variant={getModeColor(event.type)}>{getModeLabel(event.type)}</Badge>
-					<Badge size="md" variant="secondary">{event.visibility}</Badge>
-					{#if event.group}
-						<Badge size="md" variant="secondary">{event.group.name}</Badge>
+		{#snippet rsvp()}
+			{#if event.attendeesCount > 0}
+				<p class="text-base-500 dark:text-base-400 mb-6 text-sm">
+					{event.attendeesCount} attendee{event.attendeesCount !== 1 ? 's' : ''}
+					{#if event.userRsvpStatus}
+						&middot; You're {event.userRsvpStatus}
 					{/if}
-				</div>
+				</p>
+			{/if}
+			<OpenMeetRsvp userRsvpStatus={event.userRsvpStatus} />
+		{/snippet}
 
-				<!-- Date row -->
-				<div class="mb-4 flex items-center gap-4">
-					<div
-						class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 flex-col items-center justify-center overflow-hidden rounded-xl border"
+		{#snippet sidebar()}
+			<!-- Hosted By -->
+			{#if event.user}
+				<div>
+					<p
+						class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
 					>
-						<span
-							class="text-base-500 dark:text-base-400 text-[9px] leading-none font-semibold"
-						>
-							{formatMonth(startDate)}
-						</span>
-						<span class="text-base-900 dark:text-base-50 text-lg leading-tight font-bold">
-							{formatDay(startDate)}
-						</span>
-					</div>
-					<div>
-						<p class="text-base-900 dark:text-base-50 font-semibold">
-							{formatWeekday(startDate)}, {formatFullDate(startDate)}
-							{#if endDate && !isSameDay}
-								- {formatWeekday(endDate)}, {formatFullDate(endDate)}
-							{/if}
-						</p>
-						<p class="text-base-500 dark:text-base-400 text-sm">
-							{formatTime(startDate)}
-							{#if endDate && isSameDay}
-								- {formatTime(endDate)}
-							{/if}
-						</p>
-					</div>
-				</div>
-
-				<!-- Location -->
-				{#if event.location}
-					<a
-						href="https://www.google.com/maps/search/?api=1&query={encodeURIComponent(event.location)}"
-						target="_blank"
-						rel="noopener noreferrer"
-						class="mb-6 flex items-center gap-4 transition-opacity hover:opacity-80"
-					>
-						<div
-							class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 items-center justify-center rounded-xl border"
-						>
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								fill="none"
-								viewBox="0 0 24 24"
-								stroke-width="1.5"
-								stroke="currentColor"
-								class="text-base-900 dark:text-base-200 size-5"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-								/>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
-								/>
-							</svg>
-						</div>
-						<p class="text-base-900 dark:text-base-50 font-semibold">{event.location}</p>
-					</a>
-				{/if}
-
-				<!-- Attendees count -->
-				{#if event.attendeesCount > 0}
-					<p class="text-base-500 dark:text-base-400 mb-6 text-sm">
-						{event.attendeesCount} attendee{event.attendeesCount !== 1 ? 's' : ''}
-						{#if event.userRsvpStatus}
-							&middot; You're {event.userRsvpStatus}
-						{/if}
+						Hosted By
 					</p>
-				{/if}
-
-				<!-- RSVP -->
-				<OpenMeetRsvp userRsvpStatus={event.userRsvpStatus} />
-
-				<!-- Description -->
-				{#if descriptionHtml}
-					<div class="mt-8 mb-8">
-						<p
-							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-						>
-							About
-						</p>
-						<div
-							class="text-base-700 dark:text-base-300 prose dark:prose-invert max-w-none leading-relaxed wrap-break-word"
-						>
-							{@html descriptionHtml}
-						</div>
+					<div
+						class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
+					>
+						<FoxAvatar
+							src={event.user.photo?.path}
+							alt={event.user.name}
+							class="size-8 shrink-0"
+						/>
+						<span class="truncate text-sm">{event.user.name}</span>
 					</div>
-				{/if}
-			</div>
+				</div>
+			{/if}
 
-			<!-- Left column: sidebar -->
-			<div class="order-3 space-y-6 md:order-0 md:col-start-1">
-				{#if event.group}
-					<div>
-						<p
-							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-						>
-							Group
-						</p>
-						<p class="text-base-900 dark:text-base-50 text-sm font-medium">
-							{event.group.name}
-						</p>
-						<p class="text-base-500 text-xs">Your role: {event.group.role}</p>
+			<!-- Group -->
+			{#if event.group}
+				<div>
+					<p
+						class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+					>
+						Group
+					</p>
+					<p class="text-base-900 dark:text-base-50 text-sm font-medium">
+						{event.group.name}
+					</p>
+					<p class="text-base-500 text-xs">Your role: {event.group.role}</p>
+				</div>
+			{/if}
+
+			<!-- Attendees -->
+			{#if event.attendees && event.attendees.length > 0}
+				<div>
+					<p
+						class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+					>
+						Attendees
+					</p>
+					<div class="space-y-2">
+						{#each event.attendees as attendee (attendee.id)}
+							<div
+								class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
+							>
+								<FoxAvatar
+									src={attendee.user.photo?.path}
+									alt={attendee.user.name}
+									class="size-8 shrink-0"
+								/>
+								<div class="min-w-0">
+									<span class="truncate text-sm">{attendee.user.name}</span>
+									{#if attendee.role && attendee.role.name !== 'attendee'}
+										<span class="text-base-500 dark:text-base-400 ml-1 text-xs">
+											({attendee.role.name})
+										</span>
+									{/if}
+								</div>
+							</div>
+						{/each}
+						{#if event.attendeesCount > event.attendees.length}
+							<p class="text-base-500 dark:text-base-400 text-xs">
+								+{event.attendeesCount - event.attendees.length} more
+							</p>
+						{/if}
 					</div>
-				{/if}
-			</div>
-		</div>
+				</div>
+			{/if}
+		{/snippet}
+	</EventDetail>
+{:else}
+	<div class="px-6 py-24 text-center">
+		{#if data.state === 'unauthenticated'}
+			<p class="text-base-500 dark:text-base-400">Sign in to see non-public events.</p>
+		{:else}
+			<p class="text-base-500 dark:text-base-400">
+				This event doesn't exist or you don't have access.
+			</p>
+		{/if}
 	</div>
-</div>
+{/if}

--- a/src/routes/om/[slug]/+page.svelte
+++ b/src/routes/om/[slug]/+page.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+	import { Badge } from '@foxui/core';
+	import Avatar from 'svelte-boring-avatars';
+	import { marked } from 'marked';
+	import { sanitize } from '$lib/cal/sanitize';
+	import { formatMonth, formatDay, formatWeekday, formatFullDate, formatTime } from '$lib/cal/helper';
+	import OpenMeetRsvp from './OpenMeetRsvp.svelte';
+
+	let { data } = $props();
+	let event = $derived(data.event);
+
+	let startDate = $derived(new Date(event.startDate));
+	let endDate = $derived(event.endDate ? new Date(event.endDate) : null);
+
+	function getModeLabel(type: string): string {
+		if (type === 'online') return 'Virtual';
+		if (type === 'hybrid') return 'Hybrid';
+		return 'In-Person';
+	}
+
+	function getModeColor(type: string): 'cyan' | 'purple' | 'amber' | 'secondary' {
+		if (type === 'online') return 'cyan';
+		if (type === 'hybrid') return 'purple';
+		if (type === 'in-person' || type === 'in_person') return 'amber';
+		return 'secondary';
+	}
+
+	let isSameDay = $derived(
+		endDate &&
+			startDate.getFullYear() === endDate.getFullYear() &&
+			startDate.getMonth() === endDate.getMonth() &&
+			startDate.getDate() === endDate.getDate()
+	);
+
+	let descriptionHtml = $derived(
+		event.description ? sanitize(marked.parse(event.description) as string) : null
+	);
+</script>
+
+<svelte:head>
+	<title>{event.name}</title>
+	<meta name="description" content={event.description || `Event: ${event.name}`} />
+</svelte:head>
+
+<div class="min-h-screen px-6 py-12 sm:py-12">
+	<div class="mx-auto max-w-3xl">
+		<div
+			class="grid grid-cols-1 gap-8 md:grid-cols-[14rem_1fr] md:grid-rows-[auto_1fr] md:gap-x-10 md:gap-y-6 lg:grid-cols-[16rem_1fr]"
+		>
+			<!-- Left column: image -->
+			<div class="order-1 max-w-sm md:order-0 md:col-start-1 md:max-w-none">
+				{#if event.image}
+					<img
+						src={event.image}
+						alt={event.name}
+						class="border-base-200 dark:border-base-800 aspect-square w-full rounded-2xl border object-cover"
+					/>
+				{:else}
+					<div
+						class="border-base-200 dark:border-base-800 aspect-square w-full overflow-hidden rounded-2xl border [&>svg]:h-full [&>svg]:w-full"
+					>
+						<Avatar
+							size={256}
+							name={event.slug}
+							variant="marble"
+							colors={['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90']}
+							square
+						/>
+					</div>
+				{/if}
+			</div>
+
+			<!-- Right column: event details -->
+			<div class="order-2 min-w-0 md:order-0 md:col-start-2 md:row-span-2 md:row-start-1">
+				<div class="mb-2">
+					<h1
+						class="text-base-900 dark:text-base-50 text-4xl leading-tight font-bold sm:text-5xl"
+					>
+						{event.name}
+					</h1>
+				</div>
+
+				<!-- Badges -->
+				<div class="mb-8 flex gap-2">
+					<Badge size="md" variant={getModeColor(event.type)}>{getModeLabel(event.type)}</Badge>
+					<Badge size="md" variant="secondary">{event.visibility}</Badge>
+					{#if event.group}
+						<Badge size="md" variant="secondary">{event.group.name}</Badge>
+					{/if}
+				</div>
+
+				<!-- Date row -->
+				<div class="mb-4 flex items-center gap-4">
+					<div
+						class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 flex-col items-center justify-center overflow-hidden rounded-xl border"
+					>
+						<span
+							class="text-base-500 dark:text-base-400 text-[9px] leading-none font-semibold"
+						>
+							{formatMonth(startDate)}
+						</span>
+						<span class="text-base-900 dark:text-base-50 text-lg leading-tight font-bold">
+							{formatDay(startDate)}
+						</span>
+					</div>
+					<div>
+						<p class="text-base-900 dark:text-base-50 font-semibold">
+							{formatWeekday(startDate)}, {formatFullDate(startDate)}
+							{#if endDate && !isSameDay}
+								- {formatWeekday(endDate)}, {formatFullDate(endDate)}
+							{/if}
+						</p>
+						<p class="text-base-500 dark:text-base-400 text-sm">
+							{formatTime(startDate)}
+							{#if endDate && isSameDay}
+								- {formatTime(endDate)}
+							{/if}
+						</p>
+					</div>
+				</div>
+
+				<!-- Location -->
+				{#if event.location}
+					<a
+						href="https://www.google.com/maps/search/?api=1&query={encodeURIComponent(event.location)}"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="mb-6 flex items-center gap-4 transition-opacity hover:opacity-80"
+					>
+						<div
+							class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 items-center justify-center rounded-xl border"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								fill="none"
+								viewBox="0 0 24 24"
+								stroke-width="1.5"
+								stroke="currentColor"
+								class="text-base-900 dark:text-base-200 size-5"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+								/>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
+								/>
+							</svg>
+						</div>
+						<p class="text-base-900 dark:text-base-50 font-semibold">{event.location}</p>
+					</a>
+				{/if}
+
+				<!-- Attendees count -->
+				{#if event.attendeesCount > 0}
+					<p class="text-base-500 dark:text-base-400 mb-6 text-sm">
+						{event.attendeesCount} attendee{event.attendeesCount !== 1 ? 's' : ''}
+						{#if event.userRsvpStatus}
+							&middot; You're {event.userRsvpStatus}
+						{/if}
+					</p>
+				{/if}
+
+				<!-- RSVP -->
+				<OpenMeetRsvp userRsvpStatus={event.userRsvpStatus} />
+
+				<!-- Description -->
+				{#if descriptionHtml}
+					<div class="mt-8 mb-8">
+						<p
+							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+						>
+							About
+						</p>
+						<div
+							class="text-base-700 dark:text-base-300 prose dark:prose-invert max-w-none leading-relaxed wrap-break-word"
+						>
+							{@html descriptionHtml}
+						</div>
+					</div>
+				{/if}
+			</div>
+
+			<!-- Left column: sidebar -->
+			<div class="order-3 space-y-6 md:order-0 md:col-start-1">
+				{#if event.group}
+					<div>
+						<p
+							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+						>
+							Group
+						</p>
+						<p class="text-base-900 dark:text-base-50 text-sm font-medium">
+							{event.group.name}
+						</p>
+						<p class="text-base-500 text-xs">Your role: {event.group.role}</p>
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/routes/om/[slug]/OpenMeetRsvp.svelte
+++ b/src/routes/om/[slug]/OpenMeetRsvp.svelte
@@ -10,7 +10,8 @@
 	} = $props();
 
 	let submitting = $state(false);
-	let currentStatus: string | null = $state(userRsvpStatus);
+	let currentStatus: string | null = $state(null);
+	$effect(() => { currentStatus = userRsvpStatus; });
 
 	function statusLabel(status: string): string {
 		switch (status) {

--- a/src/routes/om/[slug]/OpenMeetRsvp.svelte
+++ b/src/routes/om/[slug]/OpenMeetRsvp.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { user } from '$lib/atproto/auth.svelte';
+	import { Avatar, Button } from '@foxui/core';
+
+	let {
+		userRsvpStatus
+	}: {
+		userRsvpStatus: string | null;
+	} = $props();
+
+	let submitting = $state(false);
+	let currentStatus: string | null = $state(userRsvpStatus);
+
+	function statusLabel(status: string): string {
+		switch (status) {
+			case 'confirmed': return "You're Going";
+			case 'pending': return 'RSVP Pending Approval';
+			case 'waitlist': return "You're on the Waitlist";
+			default: return `Status: ${status}`;
+		}
+	}
+
+	function statusColor(status: string): string {
+		switch (status) {
+			case 'confirmed': return 'bg-green-100 dark:bg-green-900/30';
+			case 'pending':
+			case 'waitlist': return 'bg-amber-100 dark:bg-amber-900/30';
+			default: return 'bg-base-100 dark:bg-base-900/30';
+		}
+	}
+
+	function iconColor(status: string): string {
+		switch (status) {
+			case 'confirmed': return 'text-green-600 dark:text-green-400';
+			case 'pending':
+			case 'waitlist': return 'text-amber-600 dark:text-amber-400';
+			default: return 'text-base-600 dark:text-base-400';
+		}
+	}
+</script>
+
+<div
+	class="border-base-200 dark:border-base-800 bg-base-100 dark:bg-base-950/50 mt-8 mb-2 flex flex-col justify-center rounded-2xl border p-4"
+>
+	{#if currentStatus && currentStatus !== 'cancelled'}
+		<div class="flex items-center justify-between">
+			<div class="flex items-center gap-3">
+				<div
+					class="flex size-8 items-center justify-center rounded-full {statusColor(currentStatus)}"
+				>
+					{#if currentStatus === 'confirmed'}
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-4 {iconColor(currentStatus)}">
+							<path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
+						</svg>
+					{:else}
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-4 {iconColor(currentStatus)}">
+							<path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm.75-13a.75.75 0 0 0-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 0 0 0-1.5h-3.25V5Z" clip-rule="evenodd" />
+						</svg>
+					{/if}
+				</div>
+				<p class="text-base-900 dark:text-base-50 font-semibold">{statusLabel(currentStatus)}</p>
+			</div>
+			<form
+				method="POST"
+				action="?/cancel"
+				use:enhance={() => {
+					submitting = true;
+					return async ({ result }) => {
+						submitting = false;
+						if (result.type === 'success') {
+							currentStatus = null;
+						}
+					};
+				}}
+			>
+				<Button type="submit" disabled={submitting} variant="ghost">
+					{submitting ? '...' : 'Remove'}
+				</Button>
+			</form>
+		</div>
+	{:else}
+		{#if user.profile}
+			<div class="mb-4 flex items-center gap-2">
+				<span class="text-base-500 dark:text-base-400 text-sm">Attend as</span>
+				<Avatar
+					src={user.profile.avatar}
+					alt={user.profile.displayName || user.profile.handle}
+					class="size-5"
+				/>
+				<span class="text-base-700 dark:text-base-300 truncate text-sm font-medium">
+					{user.profile.displayName || user.profile.handle}
+				</span>
+			</div>
+		{/if}
+		<div class="flex gap-3">
+			<form
+				method="POST"
+				action="?/attend"
+				class="flex-1"
+				use:enhance={() => {
+					submitting = true;
+					return async ({ result }) => {
+						submitting = false;
+						if (result.type === 'success' && result.data) {
+							currentStatus = (result.data as { status?: string }).status || 'confirmed';
+						}
+					};
+				}}
+			>
+				<Button type="submit" disabled={submitting} class="w-full">
+					{submitting ? '...' : 'Going'}
+				</Button>
+			</form>
+		</div>
+	{/if}
+</div>

--- a/src/routes/p/[actor]/+page.server.ts
+++ b/src/routes/p/[actor]/+page.server.ts
@@ -66,7 +66,7 @@ export async function load({ params, locals }: { params: { actor: string }; loca
 		(e: OpenMeetEvent) =>
 			e.userRsvpStatus &&
 			activeRsvpStatuses.has(e.userRsvpStatus) &&
-			(!e.atprotoUri || !attendingUris.has(e.atprotoUri))
+			(!e.uri || !attendingUris.has(e.uri))
 	);
 
 	return {

--- a/src/routes/p/[actor]/+page.server.ts
+++ b/src/routes/p/[actor]/+page.server.ts
@@ -5,12 +5,14 @@ import {
 	listAttendingEventsFromContrail,
 	listEventRecordsFromContrail
 } from '$lib/contrail';
+import { listMyEvents } from '$lib/openmeet/client';
+import type { OpenMeetEvent } from '$lib/openmeet/types';
 import { isActorIdentifier } from '@atcute/lexicons/syntax';
 import { error } from '@sveltejs/kit';
 
 const PREVIEW_LIMIT = 6;
 
-export async function load({ params }) {
+export async function load({ params, locals }: { params: { actor: string }; locals: App.Locals }) {
 	if (!isActorIdentifier(params.actor)) return;
 
 	const actor = params.actor;
@@ -19,34 +21,52 @@ export async function load({ params }) {
 	if (!did) throw error(404, 'Actor not found');
 
 	const now = new Date().toISOString();
+	const isOwnProfile = locals.did === did;
 
-	const [profile, upcomingResponse, pastResponse, attendingEvents] = await Promise.all([
-		getProfileFromContrail(actor),
-		listEventRecordsFromContrail({
-			hydrateRsvps: 5,
-			profiles: true,
-			sort: 'startsAt',
-			order: 'asc',
-			startsAtMin: now,
-			actor,
-			limit: PREVIEW_LIMIT + 1
-		}),
-		listEventRecordsFromContrail({
-			hydrateRsvps: 5,
-			profiles: true,
-			sort: 'startsAt',
-			order: 'desc',
-			startsAtMax: now,
-			actor,
-			limit: PREVIEW_LIMIT + 1
-		}),
-		listAttendingEventsFromContrail(actor)
-	]);
+	const [profile, upcomingResponse, pastResponse, attendingEvents, openmeetEvents] =
+		await Promise.all([
+			getProfileFromContrail(actor),
+			listEventRecordsFromContrail({
+				hydrateRsvps: 5,
+				profiles: true,
+				sort: 'startsAt',
+				order: 'asc',
+				startsAtMin: now,
+				actor,
+				limit: PREVIEW_LIMIT + 1
+			}),
+			listEventRecordsFromContrail({
+				hydrateRsvps: 5,
+				profiles: true,
+				sort: 'startsAt',
+				order: 'desc',
+				startsAtMax: now,
+				actor,
+				limit: PREVIEW_LIMIT + 1
+			}),
+			listAttendingEventsFromContrail(actor),
+			isOwnProfile && locals.openmeetToken
+				? listMyEvents(locals.openmeetToken, { fromDate: now, limit: 20 })
+				: Promise.resolve([] as OpenMeetEvent[])
+		]);
 
 	const nowDate = new Date(now);
 	const upcomingEvents = upcomingResponse ? flattenEventRecords(upcomingResponse.records) : [];
 	const pastEvents = (pastResponse ? flattenEventRecords(pastResponse.records) : []).filter(
 		(e) => new Date(e.endsAt || e.startsAt) < nowDate
+	);
+
+	// Dedup OpenMeet events that are already in Contrail's attending list
+	const attendingUris = new Set(
+		(attendingEvents ?? []).map((e) => e.uri).filter(Boolean)
+	);
+	// Only include OpenMeet events the user is actually attending (not just has access to)
+	const activeRsvpStatuses = new Set(['confirmed', 'pending', 'waitlist']);
+	const privateAttending = openmeetEvents.filter(
+		(e: OpenMeetEvent) =>
+			e.userRsvpStatus &&
+			activeRsvpStatuses.has(e.userRsvpStatus) &&
+			(!e.atprotoUri || !attendingUris.has(e.atprotoUri))
 	);
 
 	return {
@@ -55,6 +75,7 @@ export async function load({ params }) {
 		pastEvents: pastEvents.slice(0, PREVIEW_LIMIT),
 		hasMorePast: pastEvents.length > PREVIEW_LIMIT,
 		attendingEvents,
+		privateAttending,
 		actorProfile: profile,
 		actor,
 		actorDid: did

--- a/src/routes/p/[actor]/+page.svelte
+++ b/src/routes/p/[actor]/+page.svelte
@@ -32,12 +32,12 @@
 	let privateAttendingEvents = $derived(
 		[...(data.privateAttending ?? [])]
 			.filter((event: OpenMeetEvent) => {
-				const endDate = new Date(event.endDate || event.startDate);
+				const endDate = new Date(event.endsAt || event.startsAt);
 				return endDate >= now;
 			})
 			.sort(
 				(a: OpenMeetEvent, b: OpenMeetEvent) =>
-					new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+					new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime()
 			)
 	);
 </script>

--- a/src/routes/p/[actor]/+page.svelte
+++ b/src/routes/p/[actor]/+page.svelte
@@ -4,6 +4,8 @@
 	import UserProfile from '$lib/components/UserProfile.svelte';
 	import { Button } from '@foxui/core';
 	import EventCard from '$lib/components/EventCard.svelte';
+	import OpenMeetEventCard from '$lib/components/OpenMeetEventCard.svelte';
+	import type { OpenMeetEvent } from '$lib/openmeet/types';
 
 	let { data } = $props();
 
@@ -24,6 +26,18 @@
 			.sort(
 				(a: FlatEventRecord, b: FlatEventRecord) =>
 					new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime()
+			)
+	);
+
+	let privateAttendingEvents = $derived(
+		[...(data.privateAttending ?? [])]
+			.filter((event: OpenMeetEvent) => {
+				const endDate = new Date(event.endDate || event.startDate);
+				return endDate >= now;
+			})
+			.sort(
+				(a: OpenMeetEvent, b: OpenMeetEvent) =>
+					new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
 			)
 	);
 </script>
@@ -84,12 +98,15 @@
 		{/if}
 
 		<!-- Attending -->
-		{#if upcomingAttendingEvents.length > 0}
+		{#if upcomingAttendingEvents.length > 0 || privateAttendingEvents.length > 0}
 			<section class="mb-10">
 				<h2 class="text-base-900 dark:text-base-50 mb-4 text-lg font-semibold">Attending</h2>
 				<div class="space-y-5">
 					{#each upcomingAttendingEvents as event (event.uri)}
 						<EventCard {event} />
+					{/each}
+					{#each privateAttendingEvents as event (event.slug)}
+						<OpenMeetEventCard {event} />
 					{/each}
 				</div>
 			</section>
@@ -117,7 +134,7 @@
 			</section>
 		{/if}
 
-		{#if !data.upcomingEvents?.length && !upcomingAttendingEvents.length && !data.pastEvents?.length}
+		{#if !data.upcomingEvents?.length && !upcomingAttendingEvents.length && !privateAttendingEvents.length && !data.pastEvents?.length}
 			<div
 				class="border-base-200 dark:border-base-800 bg-base-100 dark:bg-base-950/50 rounded-2xl border p-8 text-center"
 			>

--- a/src/routes/p/[actor]/e/[rkey]/+page.svelte
+++ b/src/routes/p/[actor]/e/[rkey]/+page.svelte
@@ -29,8 +29,8 @@
 		typeof window !== 'undefined' ? `${window.location.origin}${eventPath}` : eventPath
 	);
 
-	let startDate = $derived(new Date(eventData.startsAt));
-	let endDate = $derived(eventData.endsAt ? new Date(eventData.endsAt) : null);
+	let startsAt = $derived(new Date(eventData.startsAt));
+	let endsAt = $derived(eventData.endsAt ? new Date(eventData.endsAt) : null);
 
 	function getModeLabel(mode: string): string {
 		if (mode.includes('virtual')) return 'Virtual';
@@ -287,8 +287,8 @@
 	imageAlt={displayImage?.alt}
 	avatarSeed={data.rkey}
 	showImage={!isBannerOnly}
-	{startDate}
-	{endDate}
+	{startsAt}
+	{endsAt}
 	{descriptionHtml}
 	location={normalizedLocation}
 >

--- a/src/routes/p/[actor]/e/[rkey]/+page.svelte
+++ b/src/routes/p/[actor]/e/[rkey]/+page.svelte
@@ -5,17 +5,15 @@
 	import { Avatar as FoxAvatar, Badge, Button } from '@foxui/core';
 	import Map from '$lib/components/Map.svelte';
 	import ShareModal from '$lib/components/ShareModal.svelte';
-	import Avatar from 'svelte-boring-avatars';
+	import EventDetail from '$lib/components/EventDetail.svelte';
 	import EventRsvp from '$lib/components/EventRsvp.svelte';
 	import EventCard from '$lib/components/EventCard.svelte';
 	import EventAttendees from './EventAttendees.svelte';
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
 	import { marked } from 'marked';
 	import { sanitize } from '$lib/cal/sanitize';
 	import { generateICalEvent } from '$lib/cal/ical';
 	import { launchConfetti } from '@foxui/visual';
-	import { formatMonth, formatDay, formatWeekday, formatFullDate, formatTime } from '$lib/cal/helper';
 
 	let { data } = $props();
 
@@ -70,7 +68,6 @@
 	}
 
 	let locationData = $derived(getLocationData(eventData.locations));
-	let location = $derived(locationData?.fullString);
 
 	let geoLocation: { lat: number; lng: number } | null = $state(null);
 
@@ -146,13 +143,6 @@
 	// Prefer thumbnail; fall back to header/banner image
 	let displayImage = $derived(thumbnailImage ?? bannerImage);
 	let isBannerOnly = $derived(!thumbnailImage && !!bannerImage);
-
-	let isSameDay = $derived(
-		endDate &&
-			startDate.getFullYear() === endDate.getFullYear() &&
-			startDate.getMonth() === endDate.getMonth() &&
-			startDate.getDate() === endDate.getDate()
-	);
 
 	let isOngoing = $derived(isEventOngoing(eventData.startsAt, eventData.endsAt));
 
@@ -267,6 +257,16 @@
 		a.click();
 		URL.revokeObjectURL(url);
 	}
+
+	let normalizedLocation = $derived(
+		locationData
+			? {
+					text: locationData.name || locationData.shortAddress,
+					secondaryText: locationData.name ? locationData.shortAddress : undefined,
+					mapsUrl: locationData.mapsUrl
+				}
+			: null
+	);
 </script>
 
 <svelte:head>
@@ -281,9 +281,19 @@
 	<meta name="twitter:image" content={ogImageUrl} />
 </svelte:head>
 
-<div class="min-h-screen px-6 py-12 sm:py-12">
-	<div class="mx-auto max-w-3xl">
-		<!-- Banner image (full width, only when no thumbnail) -->
+<EventDetail
+	name={eventData.name}
+	image={!isBannerOnly ? displayImage?.url ?? null : null}
+	imageAlt={displayImage?.alt}
+	avatarSeed={data.rkey}
+	showImage={!isBannerOnly}
+	{startDate}
+	{endDate}
+	{descriptionHtml}
+	location={normalizedLocation}
+>
+	<!-- Banner image (full width, only when no thumbnail) -->
+	{#snippet banner()}
 		{#if isBannerOnly && displayImage}
 			<img
 				src={displayImage.url}
@@ -291,103 +301,159 @@
 				class="border-base-200 dark:border-base-800 mb-8 aspect-3/1 w-full rounded-2xl border object-cover"
 			/>
 		{/if}
+	{/snippet}
 
-		<!-- Two-column layout: image left, details right -->
-		<div
-			class="grid grid-cols-1 gap-8 md:grid-cols-[14rem_1fr] md:grid-rows-[auto_1fr] md:gap-x-10 md:gap-y-6 lg:grid-cols-[16rem_1fr]"
-		>
-			<!-- Thumbnail image (left column) -->
-			{#if !isBannerOnly}
-				<div class="order-1 max-w-sm md:order-0 md:col-start-1 md:max-w-none">
-					{#if displayImage}
-						<img
-							src={displayImage.url}
-							alt={displayImage.alt}
-							class="border-base-200 dark:border-base-800 bg-base-200 dark:bg-base-950/50 aspect-square w-full rounded-2xl border object-cover"
-						/>
-					{:else}
-						<div
-							class="border-base-200 dark:border-base-800 aspect-square w-full overflow-hidden rounded-2xl border [&>svg]:h-full [&>svg]:w-full"
-						>
-							<Avatar
-								size={256}
-								name={data.rkey}
-								variant="marble"
-								colors={['#92A1C6', '#146A7C', '#F0AB3D', '#C271B4', '#C20D90']}
-								square
-							/>
-						</div>
-					{/if}
-					{#if isOwner}
-						<Button href="./{rkey}/edit" class="mt-9 w-full">Edit Event</Button>
-					{/if}
-				</div>
-			{/if}
+	{#snippet imageExtra()}
+		{#if isOwner}
+			<Button href="./{rkey}/edit" class="mt-9 w-full">Edit Event</Button>
+		{/if}
+	{/snippet}
 
-			<!-- Right column: event details -->
-			<div class="order-2 min-w-0 md:order-0 md:col-start-2 md:row-span-2 md:row-start-1">
-				<div class="mb-2">
-					<h1 class="text-base-900 dark:text-base-50 text-3xl leading-tight font-bold sm:text-4xl">
-						{eventData.name}
-					</h1>
-				</div>
+	{#snippet badges()}
+		{#if isOngoing}
+			<Badge size="md" variant="primary">
+				<span class="bg-accent-500 mr-1 inline-block size-1.5 animate-pulse rounded-full"></span>
+				Live
+			</Badge>
+		{/if}
+		{#if eventData.mode}
+			<Badge size="md" variant={getModeColor(eventData.mode)}
+				>{getModeLabel(eventData.mode)}</Badge
+			>
+		{/if}
+	{/snippet}
 
-				<!-- Badges -->
-				{#if eventData.mode || isOngoing}
-					<div class="mb-8 flex items-center gap-2">
-						{#if isOngoing}
-							<Badge size="md" variant="primary">
-								<span class="bg-accent-500 mr-1 inline-block size-1.5 animate-pulse rounded-full"
-								></span>
-								Live
-							</Badge>
-						{/if}
-						{#if eventData.mode}
-							<Badge size="md" variant={getModeColor(eventData.mode)}
-								>{getModeLabel(eventData.mode)}</Badge
+	<!-- Part of -->
+	{#snippet aboveDescription()}
+		{#if data.parentEvent}
+			<div
+				class="border-base-200 dark:border-base-800 bg-base-100 dark:bg-base-950/50 mt-8 mb-2 justify-center rounded-2xl border p-4"
+			>
+				<p
+					class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+				>
+					Part of
+				</p>
+				<EventCard event={data.parentEvent} actor="atprotocol.dev" />
+				<Button href="/p/atmosphereconf.org" size="lg" class="mt-6 w-full">
+					See full schedule
+				</Button>
+			</div>
+		{/if}
+
+		{#if did === 'did:plc:lehcqqkwzcwvjvw66uthu5oq' && rkey === '3lte3c7x43l2e'}
+			<Button href="/p/atmosphereconf.org" size="lg" class="mb-4 w-full">
+				See full schedule
+			</Button>
+		{/if}
+	{/snippet}
+
+	{#snippet rsvp()}
+		<EventRsvp
+			{eventUri}
+			eventCid={eventData.cid ?? null}
+			initialRsvpStatus={data.viewerRsvpStatus}
+			initialRsvpRkey={data.viewerRsvpRkey}
+			onrsvp={handleRsvp}
+			oncancel={handleRsvpCancel}
+		/>
+	{/snippet}
+
+	<!-- Map -->
+	{#snippet belowDescription()}
+		{#if geoLocation && locationData}
+			<div class="mt-8 mb-8">
+				<p
+					class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+				>
+					Location
+				</p>
+				<a
+					href={locationData.mapsUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="block transition-opacity hover:opacity-80"
+				>
+					<div class="h-64 w-full overflow-hidden rounded-xl">
+						<Map lat={geoLocation.lat} lng={geoLocation.lng} />
+					</div>
+					<p class="text-base-500 dark:text-base-400 mt-2 text-sm">
+						{locationData.fullString}
+					</p>
+				</a>
+			</div>
+		{/if}
+	{/snippet}
+
+	{#snippet sidebar()}
+		<!-- Hosted By -->
+		<div>
+			<p
+				class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+			>
+				Hosted By
+			</p>
+			<a
+				href={hostUrl}
+				class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium transition-opacity hover:opacity-80"
+			>
+				<FoxAvatar
+					src={hostProfile?.avatar}
+					alt={hostProfile?.displayName || hostProfile?.handle || did}
+					class="size-8 shrink-0"
+				/>
+				<span class="truncate text-sm">
+					{hostProfile?.displayName || hostProfile?.handle || did}
+				</span>
+			</a>
+		</div>
+
+		<!-- Speakers -->
+		{#if speakers.length > 0}
+			<div>
+				<p
+					class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
+				>
+					Speakers
+				</p>
+				<div class="space-y-2">
+					{#each speakers as speaker, i (speaker.id || i)}
+						{#if speaker.handle}
+							<a
+								href="/p/{speaker.handle}"
+								class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium transition-opacity hover:opacity-80"
 							>
+								<FoxAvatar src={speaker.avatar} alt={speaker.name} class="size-8 shrink-0" />
+								<span class="truncate text-sm">{speaker.name}</span>
+							</a>
+						{:else}
+							<div
+								class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
+							>
+								<FoxAvatar alt={speaker.name} class="size-8 shrink-0" />
+								<span class="truncate text-sm">{speaker.name}</span>
+							</div>
 						{/if}
-					</div>
-				{/if}
-
-				<!-- Date row -->
-				<div class="mb-4 flex items-center gap-4">
-					<div
-						class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 flex-col items-center justify-center overflow-hidden rounded-xl border"
-					>
-						<span class="text-base-500 dark:text-base-400 text-[9px] leading-none font-semibold">
-							{formatMonth(startDate)}
-						</span>
-						<span class="text-base-900 dark:text-base-50 text-lg leading-tight font-bold">
-							{formatDay(startDate)}
-						</span>
-					</div>
-					<div>
-						<p class="text-base-900 dark:text-base-50 font-semibold">
-							{formatWeekday(startDate)}, {formatFullDate(startDate)}
-							{#if endDate && !isSameDay}
-								- {formatWeekday(endDate)}, {formatFullDate(endDate)}
-							{/if}
-						</p>
-						<p class="text-base-500 dark:text-base-400 text-sm">
-							{formatTime(startDate)}
-							{#if endDate && isSameDay}
-								- {formatTime(endDate)}
-							{/if}
-						</p>
-					</div>
+					{/each}
 				</div>
+			</div>
+		{/if}
 
-				<!-- Location row -->
-				{#if locationData}
-					<a
-						href={locationData.mapsUrl}
-						target="_blank"
-						rel="noopener noreferrer"
-						class="mb-6 flex items-center gap-4 transition-opacity hover:opacity-80"
-					>
-						<div
-							class="border-base-200 dark:border-base-700 bg-base-100 dark:bg-base-950/30 flex size-12 shrink-0 items-center justify-center rounded-xl border"
+		{#if eventData.uris && eventData.uris.length > 0}
+			<!-- Links -->
+			<div>
+				<p
+					class="text-base-500 dark:text-base-400 mb-4 text-xs font-semibold tracking-wider uppercase"
+				>
+					Links
+				</p>
+				<div class="space-y-3">
+					{#each eventData.uris as link (link.name + link.uri)}
+						<a
+							href={link.uri}
+							target="_blank"
+							rel="noopener noreferrer"
+							class="text-base-700 dark:text-base-300 hover:text-base-900 dark:hover:text-base-100 flex items-center gap-1.5 text-sm transition-colors"
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
@@ -395,232 +461,53 @@
 								viewBox="0 0 24 24"
 								stroke-width="1.5"
 								stroke="currentColor"
-								class="text-base-900 dark:text-base-200 size-5"
+								class="size-3.5 shrink-0"
 							>
 								<path
 									stroke-linecap="round"
 									stroke-linejoin="round"
-									d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-								/>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z"
+									d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
 								/>
 							</svg>
-						</div>
-						<div>
-							{#if locationData.name}
-								<p class="text-base-900 dark:text-base-50 font-semibold">{locationData.name}</p>
-								<p class="text-base-500 dark:text-base-400 text-sm">{locationData.shortAddress}</p>
-							{:else}
-								<p class="text-base-900 dark:text-base-50 font-semibold">
-									{locationData.shortAddress}
-								</p>
-							{/if}
-						</div>
-					</a>
-				{/if}
-
-				<!-- Part of -->
-				{#if data.parentEvent}
-					<div
-						class="border-base-200 dark:border-base-800 bg-base-100 dark:bg-base-950/50 mt-8 mb-2 justify-center rounded-2xl border p-4"
-					>
-						<p
-							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-						>
-							Part of
-						</p>
-						<EventCard event={data.parentEvent} actor="atprotocol.dev" />
-						<Button href="/p/atmosphereconf.org" size="lg" class="mt-6 w-full">
-							See full schedule
-						</Button>
-					</div>
-				{/if}
-
-				{#if did === 'did:plc:lehcqqkwzcwvjvw66uthu5oq' && rkey === '3lte3c7x43l2e'}
-					<Button href="/p/atmosphereconf.org" size="lg" class="mb-4 w-full">
-						See full schedule
-					</Button>
-				{/if}
-
-				<EventRsvp
-					{eventUri}
-					eventCid={eventData.cid ?? null}
-					initialRsvpStatus={data.viewerRsvpStatus}
-					initialRsvpRkey={data.viewerRsvpRkey}
-					onrsvp={handleRsvp}
-					oncancel={handleRsvpCancel}
-				/>
-
-				<!-- About Event -->
-				{#if descriptionHtml}
-					<div class="mt-8 mb-8">
-						<p
-							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-						>
-							About
-						</p>
-						<div
-							class="text-base-700 dark:text-base-300 prose dark:prose-invert prose-a:text-accent-600 dark:prose-a:text-accent-400 prose-a:hover:underline prose-a:no-underline max-w-none leading-relaxed wrap-break-word"
-						>
-							{@html descriptionHtml}
-						</div>
-					</div>
-				{/if}
-
-				<!-- Map -->
-				{#if geoLocation && locationData}
-					<div class="mt-8 mb-8">
-						<p
-							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-						>
-							Location
-						</p>
-						<a
-							href={locationData.mapsUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="block transition-opacity hover:opacity-80"
-						>
-							<div class="h-64 w-full overflow-hidden rounded-xl">
-								<Map lat={geoLocation.lat} lng={geoLocation.lng} />
-							</div>
-							<p class="text-base-500 dark:text-base-400 mt-2 text-sm">
-								{locationData.fullString}
-							</p>
+							<span class="truncate">{link.name || link.uri.replace(/^https?:\/\//, '')}</span>
 						</a>
-					</div>
-				{/if}
-			</div>
-
-			<!-- Left column: sidebar info -->
-			<div class="order-3 space-y-6 md:order-0 md:col-start-1">
-				<!-- Hosted By -->
-				<div>
-					<p
-						class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-					>
-						Hosted By
-					</p>
-					<a
-						href={hostUrl}
-						class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium transition-opacity hover:opacity-80"
-					>
-						<FoxAvatar
-							src={hostProfile?.avatar}
-							alt={hostProfile?.displayName || hostProfile?.handle || did}
-							class="size-8 shrink-0"
-						/>
-						<span class="truncate text-sm">
-							{hostProfile?.displayName || hostProfile?.handle || did}
-						</span>
-					</a>
+					{/each}
 				</div>
-
-				<!-- Speakers -->
-				{#if speakers.length > 0}
-					<div>
-						<p
-							class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-						>
-							Speakers
-						</p>
-						<div class="space-y-2">
-							{#each speakers as speaker, i (speaker.id || i)}
-								{#if speaker.handle}
-									<a
-										href="/p/{speaker.handle}"
-										class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium transition-opacity hover:opacity-80"
-									>
-										<FoxAvatar src={speaker.avatar} alt={speaker.name} class="size-8 shrink-0" />
-										<span class="truncate text-sm">{speaker.name}</span>
-									</a>
-								{:else}
-									<div
-										class="text-base-900 dark:text-base-100 flex items-center gap-2.5 font-medium"
-									>
-										<FoxAvatar alt={speaker.name} class="size-8 shrink-0" />
-										<span class="truncate text-sm">{speaker.name}</span>
-									</div>
-								{/if}
-							{/each}
-						</div>
-					</div>
-				{/if}
-
-				{#if eventData.uris && eventData.uris.length > 0}
-					<!-- Links -->
-					<div>
-						<p
-							class="text-base-500 dark:text-base-400 mb-4 text-xs font-semibold tracking-wider uppercase"
-						>
-							Links
-						</p>
-						<div class="space-y-3">
-							{#each eventData.uris as link (link.name + link.uri)}
-								<a
-									href={link.uri}
-									target="_blank"
-									rel="noopener noreferrer"
-									class="text-base-700 dark:text-base-300 hover:text-base-900 dark:hover:text-base-100 flex items-center gap-1.5 text-sm transition-colors"
-								>
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										fill="none"
-										viewBox="0 0 24 24"
-										stroke-width="1.5"
-										stroke="currentColor"
-										class="size-3.5 shrink-0"
-									>
-										<path
-											stroke-linecap="round"
-											stroke-linejoin="round"
-											d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
-										/>
-									</svg>
-									<span class="truncate">{link.name || link.uri.replace(/^https?:\/\//, '')}</span>
-								</a>
-							{/each}
-						</div>
-					</div>
-				{/if}
-
-				<!-- Add to Calendar -->
-				<button
-					onclick={downloadIcs}
-					class="text-base-700 dark:text-base-300 hover:text-base-900 dark:hover:text-base-100 flex cursor-pointer items-center gap-2 text-sm font-medium transition-colors"
-				>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke-width="1.5"
-						stroke="currentColor"
-						class="size-4"
-					>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
-						/>
-					</svg>
-					Add to Calendar
-				</button>
-
-				<!-- Attendees -->
-				<EventAttendees
-					bind:this={attendeesRef}
-					going={attendees.going}
-					interested={attendees.interested}
-					goingCount={attendees.goingCount}
-					interestedCount={attendees.interestedCount}
-				/>
 			</div>
-		</div>
-	</div>
-</div>
+		{/if}
+
+		<!-- Add to Calendar -->
+		<button
+			onclick={downloadIcs}
+			class="text-base-700 dark:text-base-300 hover:text-base-900 dark:hover:text-base-100 flex cursor-pointer items-center gap-2 text-sm font-medium transition-colors"
+		>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				fill="none"
+				viewBox="0 0 24 24"
+				stroke-width="1.5"
+				stroke="currentColor"
+				class="size-4"
+			>
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5"
+				/>
+			</svg>
+			Add to Calendar
+		</button>
+
+		<!-- Attendees -->
+		<EventAttendees
+			bind:this={attendeesRef}
+			going={attendees.going}
+			interested={attendees.interested}
+			goingCount={attendees.goingCount}
+			interestedCount={attendees.interestedCount}
+		/>
+	{/snippet}
+</EventDetail>
 
 <ShareModal
 	bind:open={showShareModal}

--- a/src/routes/p/[actor]/e/[rkey]/+page.svelte
+++ b/src/routes/p/[actor]/e/[rkey]/+page.svelte
@@ -15,6 +15,7 @@
 	import { sanitize } from '$lib/cal/sanitize';
 	import { generateICalEvent } from '$lib/cal/ical';
 	import { launchConfetti } from '@foxui/visual';
+	import { formatMonth, formatDay, formatWeekday, formatFullDate, formatTime } from '$lib/cal/helper';
 
 	let { data } = $props();
 
@@ -32,30 +33,6 @@
 
 	let startDate = $derived(new Date(eventData.startsAt));
 	let endDate = $derived(eventData.endsAt ? new Date(eventData.endsAt) : null);
-
-	function formatMonth(date: Date): string {
-		return date.toLocaleDateString('en-US', { month: 'short' }).toUpperCase();
-	}
-
-	function formatDay(date: Date): number {
-		return date.getDate();
-	}
-
-	function formatWeekday(date: Date): string {
-		return date.toLocaleDateString('en-US', { weekday: 'long' });
-	}
-
-	function formatFullDate(date: Date): string {
-		const options: Intl.DateTimeFormatOptions = { month: 'long', day: 'numeric' };
-		if (date.getFullYear() !== new Date().getFullYear()) {
-			options.year = 'numeric';
-		}
-		return date.toLocaleDateString('en-US', options);
-	}
-
-	function formatTime(date: Date): string {
-		return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-	}
 
 	function getModeLabel(mode: string): string {
 		if (mode.includes('virtual')) return 'Virtual';


### PR DESCRIPTION
## What this does

Adds OpenMeet as an optional second data source so atmo can show private and unlisted events alongside public ATProto events from Contrail.

Public events already work through the ATProto pipeline (PDS → firehose → Contrail → atmo). This adds the private side — events only visible to group members or invited attendees, which never touch the protocol.

## How it works

**Auth:** After standard ATProto OAuth login (unchanged), atmo transparently acquires an OpenMeet session on the user's first page load. It calls `getServiceAuth` on the user's PDS to get a short-lived JWT targeting OpenMeet's service DID, then exchanges that for longer-lived OpenMeet tokens (~60min, cached in-memory). The user's signing key never leaves their PDS.

I chose token exchange over passing PDS service auth tokens directly to each API call because PDS tokens are short-lived (~60s). The alternative — having the DID API accept PDS tokens directly — would be simpler but adds a PDS round-trip per request.

**Data:** Private events merge into the main event feed and profile Attending section, deduplicated against Contrail by `atprotoUri`. New `/om/[slug]` route for OpenMeet event detail pages with RSVP.

**Opt-in:** Gated behind `VITE_OPENMEET_URL`. When not set, no OpenMeet code runs — no API calls, no OAuth scope changes, app is identical to upstream.

## What's new

- `src/lib/openmeet/` — auth, client, types for OpenMeet's DID API
- `src/lib/components/OpenMeetEventCard.svelte` — event card for private events
- `src/routes/om/[slug]/` — event detail page with RSVP via form actions
- Shared date formatting utils extracted to `src/lib/cal/helper.ts`

## Configuration

Three env vars (all optional, documented in `.env.example`):
- `VITE_OPENMEET_URL` — unset disables the integration
- `VITE_OPENMEET_SERVICE_DID` — DID for auth scope and token exchange
- `VITE_OPENMEET_TENANT_ID` — tenant identifier

## To Test
- [ ] Private/unlisted events from OpenMeet groups appear in main feed when authenticated
- [ ] Private attending events show on own profile page
- [ ] RSVP works on `/om/[slug]` pages
- [ ] Public events with `atprotoUri` don't duplicate
- [ ] App works normally without `VITE_OPENMEET_URL` set