### PR TITLE
Clean up map component and improve attibution styling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -9,4 +9,25 @@
 @import '@foxui/core/theme.css';
 
 @source "../node_modules/@foxui";
-	
+
+.maplibregl-ctrl-bottom-left > .maplibregl-ctrl.maplibregl-ctrl-attrib {
+	font: 7px / 10px monospace;
+	border-top-right-radius: 0.5rem;
+	border: none;
+	box-shadow: none;
+	min-height: 1rem;
+	background-color: rgba(0, 0, 0, 0.45);
+}
+
+.maplibregl-ctrl-attrib-button {
+	display: none;
+}
+
+.maplibregl-ctrl.maplibregl-ctrl-attrib .maplibregl-ctrl-attrib-inner {
+	color: rgba(255, 255, 255, 0.85);
+	line-height: 1rem;
+}
+
+.maplibregl-ctrl.maplibregl-ctrl-attrib .maplibregl-ctrl-attrib-inner a {
+	color: inherit;
+}

--- a/src/lib/components/EventView.svelte
+++ b/src/lib/components/EventView.svelte
@@ -25,7 +25,7 @@
 	import EventLinksList from './event-view/EventLinksList.svelte';
 	import AddToCalendarButton from './event-view/AddToCalendarButton.svelte';
 	import InviteShareFlow from './event-view/InviteShareFlow.svelte';
-	import { buildDescriptionHtml, getLocationData, resolveGeoLocation } from './event-view/format';
+	import { buildDescriptionHtml, getLocationData, resolveGeoLocation, type GeoLocation } from './event-view/format';
 
 	let { data } = $props();
 
@@ -50,7 +50,7 @@
 	let endDate = $derived(eventData.endsAt ? new Date(eventData.endsAt) : null);
 
 	let locationData = $derived(getLocationData(eventData.locations));
-	let geoLocation: { lat: number; lng: number } | null = $state(null);
+	let geoLocation: GeoLocation | null = $state(null);
 
 	let showShareModal = $state(false);
 	let shareModalTitle = $state('Event created!');

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -1,128 +1,27 @@
 <script lang="ts">
-	import { MapLibre, Projection, Marker } from 'svelte-maplibre-gl';
-	import type maplibregl from 'maplibre-gl';
+	import { MapLibre, Projection, Marker, AttributionControl } from 'svelte-maplibre-gl';
+	import maplibregl from 'maplibre-gl';
 
-	let {
-		lat,
-		lng,
-		zoom = 14
-	}: {
-		lat: number;
-		lng: number;
-		zoom?: number;
-	} = $props();
+	let { lat, lng, zoom = 11 }: { lat: number; lng: number; zoom?: number } = $props();
 
-	let center = $state({ lng, lat });
-	let showAttribution = $state(false);
 	let map: maplibregl.Map | undefined = $state();
-
-	const fixedCenter = { lng, lat };
-
-	function handleZoom() {
-		if (map) {
-			map.setCenter(fixedCenter);
-		}
-	}
-
-	$effect(() => {
-		if (map) {
-			map.getCanvas().style.touchAction = 'pan-x pan-y';
-		}
-	});
 </script>
 
-<div
-	class="relative isolate h-full w-full overflow-hidden rounded-xl"
-	onfocusin={(e) => {
-		if (e.target instanceof HTMLElement) e.target.blur();
-	}}
+<MapLibre
+	bind:map
+	class="h-full w-full overflow-hidden rounded-xl"
+	style="https://tiles.openfreemap.org/styles/liberty"
+	{zoom}
+	center={[lng, lat]}
+	attributionControl={false}
 >
-	<MapLibre
-		bind:map
-		class="h-full w-full"
-		style="https://tiles.openfreemap.org/styles/liberty"
-		{zoom}
-		{center}
-		attributionControl={false}
-		dragPan={false}
-		dragRotate={false}
-		keyboard={false}
-		touchZoomRotate={true}
-		scrollZoom={true}
-		boxZoom={false}
-		pitchWithRotate={false}
-		touchPitch={false}
-		onzoom={handleZoom}
-	>
-		<Projection type="globe" />
-
-		<Marker bind:lnglat={center}>
-			{#snippet content()}
-				<div class="from-accent-400 size-10 rounded-full bg-radial via-transparent p-3">
-					<div class="bg-accent-500 size-4 rounded-full ring-2 ring-white"></div>
-				</div>
-			{/snippet}
-		</Marker>
-	</MapLibre>
-
-	{#snippet infoIcon()}
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			width="24"
-			height="24"
-			fill-rule="evenodd"
-			viewBox="0 0 20 20"
-		>
-			<path
-				d="M4 10a6 6 0 1 0 12 0 6 6 0 1 0-12 0m5-3a1 1 0 1 0 2 0 1 1 0 1 0-2 0m0 3a1 1 0 1 1 2 0v3a1 1 0 1 1-2 0"
-			/>
-		</svg>
-	{/snippet}
-
-	{#if showAttribution}
-		<div
-			class="absolute right-2.5 bottom-2.5 z-10 rounded-xl bg-white text-black"
-			style="width: calc(100% - 20px); max-width: 12rem;"
-		>
-			<button
-				class="float-right flex size-6 cursor-pointer items-center justify-center rounded-full shadow-[0_0_6px_rgba(59,130,246,0.6)]"
-				onclick={() => (showAttribution = false)}
-				aria-label="Toggle attribution"
-			>
-				{@render infoIcon()}
-			</button>
-			<div class="p-2 text-left text-xs leading-snug text-black/75">
-				<a
-					href="https://openfreemap.org"
-					target="_blank"
-					rel="noopener noreferrer"
-					class="text-black/75 no-underline hover:underline"
-					onclick={(e) => e.stopPropagation()}>OpenFreeMap</a
-				>
-				<a
-					href="https://openmaptiles.org"
-					target="_blank"
-					rel="noopener noreferrer"
-					class="text-black/75 no-underline hover:underline"
-					onclick={(e) => e.stopPropagation()}>© OpenMapTiles</a
-				>
-				Data from
-				<a
-					href="https://www.openstreetmap.org/copyright"
-					target="_blank"
-					rel="noopener noreferrer"
-					class="text-black/75 no-underline hover:underline"
-					onclick={(e) => e.stopPropagation()}>OpenStreetMap</a
-				>
+	<AttributionControl position="bottom-left" compact={false} />
+	<Projection type="globe" />
+	<Marker lnglat={[lng, lat]}>
+		{#snippet content()}
+			<div class="from-accent-400 size-10 rounded-full bg-radial via-transparent p-3">
+				<div class="bg-accent-500 size-4 rounded-full ring-2 ring-white"></div>
 			</div>
-		</div>
-	{:else}
-		<button
-			class="absolute right-2.5 bottom-2.5 z-10 flex size-6 items-center justify-center rounded-full bg-white text-black"
-			onclick={() => (showAttribution = true)}
-			aria-label="Toggle attribution"
-		>
-			{@render infoIcon()}
-		</button>
-	{/if}
-</div>
+		{/snippet}
+	</Marker>
+</MapLibre>

--- a/src/lib/components/event-view/EventLocationBlock.svelte
+++ b/src/lib/components/event-view/EventLocationBlock.svelte
@@ -6,7 +6,7 @@
 
 {#if locationData}
 	<a
-		href={locationData.mapsUrl}
+		href={locationData.googleMapsUrl}
 		target="_blank"
 		rel="noopener noreferrer"
 		class="mb-6 flex items-center gap-4 transition-opacity hover:opacity-80"

--- a/src/lib/components/event-view/EventLocationMap.svelte
+++ b/src/lib/components/event-view/EventLocationMap.svelte
@@ -1,35 +1,72 @@
 <script lang="ts">
+	import { Badge } from '@foxui/core';
 	import Map from '$lib/components/Map.svelte';
-	import type { LocationData } from './format';
+	import type { LocationData, GeoLocation } from './format';
 
 	let {
 		locationData,
 		geoLocation
 	}: {
 		locationData: LocationData | null;
-		geoLocation: { lat: number; lng: number } | null;
+		geoLocation: GeoLocation | null;
 	} = $props();
+
+	let copied = $state(false);
+
+	async function copyCoords() {
+		if (!geoLocation) return;
+		const text = `${geoLocation.lat.toFixed(5)}, ${geoLocation.lng.toFixed(5)}`;
+		try {
+			await navigator.clipboard.writeText(text);
+			copied = true;
+			setTimeout(() => (copied = false), 2000);
+		} catch {}
+	}
 </script>
 
 {#if geoLocation && locationData}
 	<div class="mt-8 mb-8">
-		<p
-			class="text-base-500 dark:text-base-400 mb-3 text-xs font-semibold tracking-wider uppercase"
-		>
-			Location
-		</p>
-		<a
-			href={locationData.mapsUrl}
-			target="_blank"
-			rel="noopener noreferrer"
-			class="block transition-opacity hover:opacity-80"
-		>
-			<div class="h-64 w-full overflow-hidden rounded-xl">
-				<Map lat={geoLocation.lat} lng={geoLocation.lng} />
-			</div>
-			<p class="text-base-500 dark:text-base-400 mt-2 text-sm">
-				{locationData.fullString}
+		<div class="mb-3 flex items-baseline gap-2">
+			<p class="text-base-500 dark:text-base-400 text-xs font-semibold tracking-wider uppercase">
+				Location:
 			</p>
-		</a>
+			<button
+				type="button"
+				onclick={copyCoords}
+				class="ml-auto cursor-pointer transition-opacity active:opacity-60"
+				title="Copy coordinates"
+				aria-label="Copy coordinates"
+			>
+				<Badge size="sm" variant="secondary" class="font-mono">
+					{copied
+						? 'Copied!'
+						: `${geoLocation.lat.toFixed(5)}, ${geoLocation.lng.toFixed(5)}`}
+				</Badge>
+			</button>
+		</div>
+		<div class="h-64 w-full overflow-hidden rounded-xl">
+			<Map lat={geoLocation.lat} lng={geoLocation.lng} />
+		</div>
+		<p class="text-base-700 dark:text-base-200 mt-3 text-sm">{locationData.fullString}</p>
+		<p class="text-base-500 dark:text-base-400 mt-1 text-xs">
+			Open in
+			<a
+				href={geoLocation.googleMapsUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-base-700 dark:text-base-300 hover:underline"
+			>
+				Google Maps
+			</a>
+			|
+			<a
+				href={geoLocation.osmUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-base-700 dark:text-base-300 hover:underline"
+			>
+				OpenStreetMap
+			</a>
+		</p>
 	</div>
 {/if}

--- a/src/lib/components/event-view/format.ts
+++ b/src/lib/components/event-view/format.ts
@@ -45,11 +45,11 @@ export type LocationData = {
 	shortAddress: string;
 	fullAddress: string;
 	fullString: string;
-	mapsUrl: string;
+	googleMapsUrl: string;
 };
 
 export function getLocationData(locations: FlatEventRecord['locations']): LocationData | null {
-	if (!locations || locations.length === 0) return null;
+	if (!locations?.length) return null;
 
 	const loc = locations.find((v) => v.$type === 'community.lexicon.location.address') as
 		| { name?: string; street?: string; locality?: string; region?: string; country?: string }
@@ -64,16 +64,33 @@ export function getLocationData(locations: FlatEventRecord['locations']): Locati
 	const fullAddress = fullParts.join(', ');
 	const displayName = loc.name || undefined;
 	const fullString = displayName ? `${displayName}, ${fullAddress}` : fullAddress;
-	const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(fullString)}`;
+	const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(fullString)}`;
 
-	return { name: displayName, shortAddress, fullAddress, fullString, mapsUrl };
+	return { name: displayName, shortAddress, fullAddress, fullString, googleMapsUrl };
+}
+
+export type GeoLocation = {
+	lat: number;
+	lng: number;
+	googleMapsUrl: string;
+	osmUrl: string;
+};
+
+function geoUrls(lat: number, lng: number, osmType?: string, osmId?: number) {
+	return {
+		googleMapsUrl: `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`,
+		osmUrl:
+			osmType && osmId
+				? `https://www.openstreetmap.org/${osmType}/${osmId}`
+				: `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lng}#map=17/${lat}/${lng}`
+	};
 }
 
 export async function resolveGeoLocation(
 	locations: FlatEventRecord['locations'],
 	locationData: LocationData | null
-): Promise<{ lat: number; lng: number } | null> {
-	if (!locations || locations.length === 0) return null;
+): Promise<GeoLocation | null> {
+	if (!locations?.length) return null;
 
 	const geo = locations.find((v) => v.$type === 'community.lexicon.location.geo') as
 		| { latitude?: string; longitude?: string }
@@ -81,18 +98,25 @@ export async function resolveGeoLocation(
 	if (geo?.latitude && geo?.longitude) {
 		const lat = parseFloat(geo.latitude);
 		const lng = parseFloat(geo.longitude);
-		if (!isNaN(lat) && !isNaN(lng)) return { lat, lng };
+		if (!isNaN(lat) && !isNaN(lng)) return { lat, lng, ...geoUrls(lat, lng) };
 	}
 
-	const addressQuery = locationData?.fullAddress;
-	if (!addressQuery) return null;
+	if (!locationData?.fullAddress) return null;
 
 	try {
-		const r = await fetch(`/api/geocoding?q=${encodeURIComponent(addressQuery)}`);
+		const r = await fetch(`/api/geocoding?q=${encodeURIComponent(locationData.fullAddress)}`);
 		if (!r.ok) return null;
-		const data = (await r.json()) as Record<string, unknown> | null;
-		if (!data || !data.lat || !data.lon) return null;
-		return { lat: parseFloat(data.lat as string), lng: parseFloat(data.lon as string) };
+		const data = (await r.json()) as {
+			lat?: string;
+			lon?: string;
+			osm_type?: string;
+			osm_id?: number;
+		} | null;
+		if (!data?.lat || !data?.lon) return null;
+		const lat = parseFloat(data.lat);
+		const lng = parseFloat(data.lon);
+		if (isNaN(lat) || isNaN(lng)) return null;
+		return { lat, lng, ...geoUrls(lat, lng, data.osm_type, data.osm_id) };
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
Hey Flo,

Really cool site! 

The changes here are to improve the map and include a couple things:

- added a minimal styled attribution to the bottom left of the map. Should look good across screen sizes, and removes the trick to hide the default attribution
- Added a link to open the location in OSM for users who prefer it over Google Maps.
- Displayed the coordinates, which can now be clicked to copy them to the clipboard.
- Changed the default zoom level of the map to be a bit more zoomed out... imo this is a better view for an "overview" of events and I think people will zoom in if they care about exact location but I don't have strong opinions here.
- Changed it so the map is a proper slippy map without any weird behaviou

I didn't think too much about the styling overall, maybe you want to touch it up.

here is a before and after:

https://github.com/user-attachments/assets/4c822b07-0502-4aa3-b74a-5d31bc26c889

https://github.com/user-attachments/assets/070dce27-af2a-43a2-bca8-682d2a5507fe