### PR TITLE
fix(cron): split ingest into drain + hard-timeout budgets so the cursor save isn't pre-empted

### DIFF
--- a/apps/web/src/routes/api/cron/+server.ts
+++ b/apps/web/src/routes/api/cron/+server.ts
@@ -25,7 +25,28 @@ export const POST: RequestHandler = async ({ request, platform }) => {
 	// (which previously also took the bot down with it).
 	try {
 		await ensureInit(db);
-		await contrail.ingest({}, db);
+		// Two deliberately-split budgets. contrail saves the jetstream cursor LAST in
+		// runIngestCycle — after the drain, applyEvents, and the per-DID
+		// refreshStaleIdentities network tail. If this handler aborts before that
+		// save runs, the cursor never advances and the next tick re-replays the same
+		// window forever (the "redoing the same work" loop). A backlogged stream made
+		// this certain: a 30s drain consumed the whole budget, leaving no room for a
+		// tail that needs more, so the cursor was never persisted.
+		//   DRAIN — contrail's internal deadline; how long we pull from jetstream.
+		//           Kept well under the hard cap so the tail (incl. saveCursor) fits.
+		//   HARD  — backstop only, for a genuine hang (e.g. a DID resolution that
+		//           never returns). Sized never to pre-empt the cursor save in a
+		//           normal cycle, and under the cron interval so ticks don't overlap.
+		//           Scheduled invocations get ~15min wall-clock and this is I/O-bound,
+		//           so the tail has ample room.
+		const DRAIN_TIMEOUT_MS = 20_000;
+		const HARD_TIMEOUT_MS = 55_000;
+		await Promise.race([
+			contrail.ingest({ timeoutMs: DRAIN_TIMEOUT_MS }, db),
+			new Promise((_, reject) =>
+				setTimeout(() => reject(new Error('ingest hard timeout')), HARD_TIMEOUT_MS)
+			)
+		]);
 	} catch (e) {
 		console.error('[cron] contrail.ingest failed:', e);
 	}


### PR DESCRIPTION
## What

Splits the cron ingest timeout into two budgets so the jetstream cursor save can't be pre-empted.

The handler previously raced `contrail.ingest` against a single timeout. contrail saves the jetstream cursor **last** in `runIngestCycle` — after the drain, `applyEvents`, and the per-DID `refreshStaleIdentities` network tail. When a backlogged stream let the drain consume the whole budget, the race rejected *before* the cursor was persisted, so the next tick re-replayed the same window and the worker churned the same events indefinitely.

## Change

- `DRAIN_TIMEOUT_MS = 20_000` — passed to `contrail.ingest({ timeoutMs })`; contrail's internal deadline for how long it pulls from jetstream. Kept well under the hard cap so the identity-refresh tail (incl. the cursor save) has room to finish.
- `HARD_TIMEOUT_MS = 55_000` — outer backstop, only for a genuine hang (e.g. a DID resolution that never returns). Sized never to pre-empt the cursor save in a normal cycle, and under the cron interval so ticks don't overlap.

One file, no API additions — relies on the existing published `ingest({ timeoutMs })` option.

## Context

This is the worker-side counterpart to the contrail-side cursor-ordering fixes (cursor-save-before-identity-refresh + single-instance no-cursor-rollback) that landed in contrail 0.12.1. Proven in a multi-day soak on a live worker against the public Bluesky firehose: the "redoing the same work" replay loop disappeared once both halves were in place.

## Test plan

- [x] Soaked on a live Cloudflare Worker (public firehose, `*/1` cron) for multiple days — cursor advances monotonically, no repeated-window replay.
- [x] CI typecheck / build
