### PR TITLE
fix(search): dedupe events by uri to prevent duplicate-key crash

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,7 +65,7 @@
 	"dependencies": {
 		"@atcute/bluesky-richtext-parser": "^2.1.1",
 		"@atcute/jetstream": "^1.1.2",
-		"@atmo-dev/contrail": "^0.12.1",
+		"@atmo-dev/contrail": "^0.12.2",
 		"@atmo-dev/events-ui": "workspace:*",
 		"@ethercorps/sveltekit-og": "^4.2.1",
 		"@foxui/colors": "^0.8.5",

--- a/apps/web/src/lib/components/EventList.svelte
+++ b/apps/web/src/lib/components/EventList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { FlatEventRecord } from '$lib/contrail';
 	import { loadMoreEvents } from '$lib/contrail/events.remote';
+	import { dedupeByUri } from '$lib/dedupe-by-uri';
 	import { EventCard } from '@atmo-dev/events-ui';
 
 	let {
@@ -30,7 +31,11 @@
 		currentHandles = { ...handles };
 	});
 
-	let allEvents = $derived([...events, ...extraEvents]);
+	// Dedupe by uri so the keyed {#each} below cannot collide: a dirty source
+	// (e.g. the D1 FTS path fanning one event out across duplicate fts rows) or a
+	// uri overlapping between the initial page and a loadMore page would otherwise
+	// repeat a key and crash hydration with each_key_duplicate.
+	let allEvents = $derived(dedupeByUri([...events, ...extraEvents]));
 
 	async function loadMore() {
 		if (!currentCursor || loading) return;

--- a/apps/web/src/lib/dedupe-by-uri.test.ts
+++ b/apps/web/src/lib/dedupe-by-uri.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { dedupeByUri } from './dedupe-by-uri';
+
+describe('dedupeByUri', () => {
+	it('collapses repeated uris to the first occurrence, preserving order', () => {
+		const items = [
+			{ uri: 'at://a', name: 'first' },
+			{ uri: 'at://b', name: 'second' },
+			{ uri: 'at://a', name: 'duplicate of first' },
+			{ uri: 'at://c', name: 'third' }
+		];
+
+		expect(dedupeByUri(items)).toEqual([
+			{ uri: 'at://a', name: 'first' },
+			{ uri: 'at://b', name: 'second' },
+			{ uri: 'at://c', name: 'third' }
+		]);
+	});
+
+	it('yields a uri-unique list so a keyed {#each} cannot collide on duplicate keys', () => {
+		// An FTS fan-out (one record joined to duplicate fts rows) returns the same
+		// event twice. The keyed each in EventList crashes hydration on a repeated
+		// key, blanking the page; deduping by uri is what prevents that.
+		const items = [{ uri: 'at://x' }, { uri: 'at://x' }, { uri: 'at://x' }];
+
+		const result = dedupeByUri(items);
+
+		expect(result).toHaveLength(1);
+		expect(new Set(result.map((r) => r.uri)).size).toBe(result.length);
+	});
+
+	it('returns an empty array unchanged', () => {
+		expect(dedupeByUri([])).toEqual([]);
+	});
+
+	it('leaves an already-unique list untouched', () => {
+		const items = [{ uri: 'at://a' }, { uri: 'at://b' }];
+		expect(dedupeByUri(items)).toEqual(items);
+	});
+});

--- a/apps/web/src/lib/dedupe-by-uri.ts
+++ b/apps/web/src/lib/dedupe-by-uri.ts
@@ -1,0 +1,20 @@
+/**
+ * Keep the first occurrence of each uri, preserving order.
+ *
+ * Guards the keyed `{#each ... (event.uri)}` lists (e.g. EventList): a data
+ * source can return the same record more than once — notably the D1 full-text
+ * search path, where an event joined to duplicate `fts` rows fans out into
+ * identical rows. A repeated key makes Svelte throw `each_key_duplicate` during
+ * hydration, which unmounts the page (renders blank after a flash of content).
+ * Deduping by uri keeps the keys unique regardless of how dirty the source is.
+ */
+export function dedupeByUri<T extends { uri: string }>(items: T[]): T[] {
+	const seen = new Set<string>();
+	const out: T[] = [];
+	for (const item of items) {
+		if (seen.has(item.uri)) continue;
+		seen.add(item.uri);
+		out.push(item);
+	}
+	return out;
+}

--- a/apps/web/src/routes/(app)/+page.server.ts
+++ b/apps/web/src/routes/(app)/+page.server.ts
@@ -13,6 +13,7 @@ import {
 import { getSpacesClient } from '$lib/spaces/server/client';
 import { spacesAvailable } from '$lib/spaces/config';
 import { cachedRead } from '$lib/server/edge-cache';
+import { dedupeByUri } from '$lib/dedupe-by-uri';
 import type { PageServerLoad } from './$types';
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -76,12 +77,7 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
 
 		const hostingEvents = hostingResponse ? flattenEventRecords(hostingResponse.records) : [];
 
-		const seen = new Set<string>();
-		const all = [...rsvpEvents, ...hostingEvents].filter((e) => {
-			if (seen.has(e.uri)) return false;
-			seen.add(e.uri);
-			return true;
-		});
+		const all = dedupeByUri([...rsvpEvents, ...hostingEvents]);
 
 		const nowMs = Date.now();
 		const upcoming = all

--- a/apps/web/src/routes/(app)/calendar/+page.server.ts
+++ b/apps/web/src/routes/(app)/calendar/+page.server.ts
@@ -6,6 +6,7 @@ import {
 } from '$lib/contrail';
 import { getSpacesClient } from '$lib/spaces/server/client';
 import { spacesAvailable } from '$lib/spaces/config';
+import { dedupeByUri } from '$lib/dedupe-by-uri';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals, platform }) => {
@@ -42,12 +43,7 @@ export const load: PageServerLoad = async ({ locals, platform }) => {
 
 	const hostingEvents = hostingResponse ? flattenEventRecords(hostingResponse.records) : [];
 
-	const seen = new Set<string>();
-	const all = [...rsvpEvents, ...hostingEvents].filter((e) => {
-		if (seen.has(e.uri)) return false;
-		seen.add(e.uri);
-		return true;
-	});
+	const all = dedupeByUri([...rsvpEvents, ...hostingEvents]);
 
 	const nowMs = Date.now();
 	const upcoming = all

--- a/apps/web/src/routes/(app)/p/[actor]/calendar.ics/+server.ts
+++ b/apps/web/src/routes/(app)/p/[actor]/calendar.ics/+server.ts
@@ -8,6 +8,7 @@ import {
 	getServerClient,
 	listEventRecordsFromContrail
 } from '$lib/contrail';
+import { dedupeByUri } from '$lib/dedupe-by-uri';
 
 export async function GET({ params, platform }) {
 	if (!isActorIdentifier(params.actor)) {
@@ -54,14 +55,9 @@ export async function GET({ params, platform }) {
 
 		const hostingEvents = hostingResponse ? flattenEventRecords(hostingResponse.records) : [];
 
-		const seen = new Set<string>();
-		const allEvents = [...rsvpEvents, ...hostingEvents]
-			.filter((e) => {
-				if (seen.has(e.uri)) return false;
-				seen.add(e.uri);
-				return true;
-			})
-			.sort((a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime());
+		const allEvents = dedupeByUri([...rsvpEvents, ...hostingEvents]).sort(
+			(a, b) => new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime()
+		);
 
 		const events: ICalEvent[] = allEvents.map((r) => ({
 			eventData: r,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       '@atmo-dev/contrail':
-        specifier: ^0.12.1
-        version: 0.12.1(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))
+        specifier: ^0.12.2
+        version: 0.12.2(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))
       '@atmo-dev/events-ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -394,14 +394,14 @@ packages:
   '@atcute/xrpc-server@0.1.12':
     resolution: {integrity: sha512-70KIerQlljp5+s6t0u6YNN9klEboQUZa2hhoi/hmXIO1cIKEORettTMctnyjfcCJaSfAuj42dxPu51GTZBlm8w==}
 
-  '@atmo-dev/contrail-appview@0.12.1':
-    resolution: {integrity: sha512-cGSDLrwqAhQeJ1vpiqq1ZNycNbdxuaj7XI8EqawZCA9bKL2sm9P6jzgwCHIA/ttCiVXGg0s4pWig9XcXKuxUEw==}
+  '@atmo-dev/contrail-appview@0.12.2':
+    resolution: {integrity: sha512-FekVluCYzXW58fKPiAORFo+7BdPYrImxv7+oA8l3LHuuNOaKe+FEjmq4cI74Nz9vBLURDSb27xr/gCPuHfHxUg==}
 
-  '@atmo-dev/contrail-authority@0.12.1':
-    resolution: {integrity: sha512-q9TTi3l6nWwtkoCGdzDcvDB2jR5gAQW2N4cwV54tBbKEP/1jGXYpfUGsY2etliTduPJCQ4dzFiHfckX9LxrFWQ==}
+  '@atmo-dev/contrail-authority@0.12.2':
+    resolution: {integrity: sha512-FJRjucOB8n0QxU7yWKkiGFGL3P4E4UeoPwG4rcda4992POVacmX2Zvly0Xse4Md5ovWTEHbWpZWsVfMD+qp6pQ==}
 
-  '@atmo-dev/contrail-base@0.12.1':
-    resolution: {integrity: sha512-tAxxUL5ABZcu2cM9THjPZbhHXilgNUzjcxTyKOyJMOn+kTaPM+rLeWzfGmO74x/C4hwp19xAOI1GE+U/KeadJQ==}
+  '@atmo-dev/contrail-base@0.12.2':
+    resolution: {integrity: sha512-7dYTfmfXhuDJK8KHnTZ/Qj4dkLxhApuyysZTQaxFwkdRlr/mPspeZ5wAyPU5uAy045GwVLRLZnrJLTHdW9QuUw==}
     peerDependencies:
       pg: ^8.0.0
     peerDependenciesMeta:
@@ -412,11 +412,11 @@ packages:
     resolution: {integrity: sha512-rb22K1H0NYp9Y7Okui/ny42T3X4xfj795p+pPrtWeBsio2ZsK9uuFtn3E+XnB314sGSUQQSe0FtkgVCUjLT+uQ==}
     hasBin: true
 
-  '@atmo-dev/contrail-record-host@0.12.1':
-    resolution: {integrity: sha512-dgDq3WFhGrgPCHuc0s3RhWTLKnzASr098PYSITnzXFMoAW8Q8ZeJV+/7UsWAe5OmsjnaJKSGEi906EsaMCu9mg==}
+  '@atmo-dev/contrail-record-host@0.12.2':
+    resolution: {integrity: sha512-IdXwnU9K18zl1Fk6FvRHP/QMiXq3noJElP2A8wgbjTZe5ueOBpTUcI1hvlrm4AW794UUkJmWSU0cBdIzjJkjaA==}
 
-  '@atmo-dev/contrail@0.12.1':
-    resolution: {integrity: sha512-YwC1+ChwmWyWNE23EXRA/Sl5qX8Mj7TRox4CgiJT1ta9KGlPoHwMFgfXtc6psZaNix2dRu3PtW+D9ECPEW0SxA==}
+  '@atmo-dev/contrail@0.12.2':
+    resolution: {integrity: sha512-VrJpZeV+Tv5c25Dksn0X550oBTMh4sxcWUPLSRcd7FjhCGcyV2tA7z5HTQyPGeFMKGNReMs2Bnjp80sy2s9plA==}
     hasBin: true
     peerDependencies:
       pg: ^8.0.0
@@ -3823,7 +3823,7 @@ snapshots:
       '@badrap/valita': 0.4.6
       nanoid: 5.1.7
 
-  '@atmo-dev/contrail-appview@0.12.1':
+  '@atmo-dev/contrail-appview@0.12.2':
     dependencies:
       '@atcute/atproto': 3.1.10
       '@atcute/cbor': 2.3.2
@@ -3834,24 +3834,24 @@ snapshots:
       '@atcute/jetstream': 1.1.2
       '@atcute/lexicons': 1.2.9
       '@atcute/xrpc-server': 0.1.12
-      '@atmo-dev/contrail-authority': 0.12.1
-      '@atmo-dev/contrail-base': 0.12.1
-      '@atmo-dev/contrail-record-host': 0.12.1
+      '@atmo-dev/contrail-authority': 0.12.2
+      '@atmo-dev/contrail-base': 0.12.2
+      '@atmo-dev/contrail-record-host': 0.12.2
       hono: 4.12.14
     transitivePeerDependencies:
       - pg
       - react
 
-  '@atmo-dev/contrail-authority@0.12.1':
+  '@atmo-dev/contrail-authority@0.12.2':
     dependencies:
       '@atcute/cid': 2.4.1
       '@atcute/lexicons': 1.2.9
-      '@atmo-dev/contrail-base': 0.12.1
+      '@atmo-dev/contrail-base': 0.12.2
       hono: 4.12.14
     transitivePeerDependencies:
       - pg
 
-  '@atmo-dev/contrail-base@0.12.1':
+  '@atmo-dev/contrail-base@0.12.2':
     dependencies:
       '@atcute/atproto': 3.1.10
       '@atcute/cid': 2.4.1
@@ -3871,15 +3871,15 @@ snapshots:
       - react
       - wrangler
 
-  '@atmo-dev/contrail-record-host@0.12.1':
+  '@atmo-dev/contrail-record-host@0.12.2':
     dependencies:
       '@atcute/cid': 2.4.1
-      '@atmo-dev/contrail-base': 0.12.1
+      '@atmo-dev/contrail-base': 0.12.2
       hono: 4.12.14
     transitivePeerDependencies:
       - pg
 
-  '@atmo-dev/contrail@0.12.1(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))':
+  '@atmo-dev/contrail@0.12.2(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))':
     dependencies:
       '@atcute/atproto': 3.1.10
       '@atcute/cbor': 2.3.2
@@ -3890,10 +3890,10 @@ snapshots:
       '@atcute/jetstream': 1.1.2
       '@atcute/lexicons': 1.2.9
       '@atcute/xrpc-server': 0.1.12
-      '@atmo-dev/contrail-appview': 0.12.1
-      '@atmo-dev/contrail-authority': 0.12.1
-      '@atmo-dev/contrail-base': 0.12.1
-      '@atmo-dev/contrail-record-host': 0.12.1
+      '@atmo-dev/contrail-appview': 0.12.2
+      '@atmo-dev/contrail-authority': 0.12.2
+      '@atmo-dev/contrail-base': 0.12.2
+      '@atmo-dev/contrail-record-host': 0.12.2
       cac: 7.0.0
       hono: 4.12.14
       jiti: 2.6.1


### PR DESCRIPTION
A keyed `{#each ... (event.uri)}` in `EventList` crashes hydration with `each_key_duplicate` when an event appears more than once, blanking the page after a flash of content.

Two sources can repeat a uri:
1. The D1 full-text search path, where an event joined to duplicate `fts` rows fans out into identical rows.
2. A uri overlapping between the initial page and a `loadMore` page.

This dedupes the combined list by uri at the single render chokepoint (`EventList`), so keys stay unique regardless of how dirty the source is. Companion to the contrail FTS-dedupe fix ([flo-bit/contrail#61](https://github.com/flo-bit/contrail/pull/61)), which stops new duplicate rows at the source; this is the UI-side safety net and also independently fixes the pagination-overlap case.

## Test plan
- `apps/web/src/lib/dedupe-by-uri.test.ts` — 4 cases (order-preserving dedupe, collapse-to-one, empty, already-unique)
- full web unit suite: 54 passed, 2 skipped
- `npm run check`: no new problems in the touched files